### PR TITLE
UnitIdType Enum for Better Type Safety

### DIFF
--- a/microdata_tools/validation/__init__.py
+++ b/microdata_tools/validation/__init__.py
@@ -35,7 +35,7 @@ def _validate_dataset_name(dataset_name: str) -> None:
 
 def get_unit_id_type_for_unit_type(
     unit_id: UnitType,
-) -> Union[str, UnitIdType]:
+) -> Union[None, UnitIdType]:
     """
     Returns the unitIdType for the supplied unitType. Returns None
     if supplied unitType has no attached unitIdType.

--- a/microdata_tools/validation/__init__.py
+++ b/microdata_tools/validation/__init__.py
@@ -11,6 +11,7 @@ from microdata_tools.validation.steps import (
     data_reader,
     metadata_enricher,
 )
+from microdata_tools.validation.model.metadata import UnitType, UnitIdType
 
 
 def _validate_dataset_name(dataset_name: str) -> None:
@@ -32,7 +33,9 @@ def _validate_dataset_name(dataset_name: str) -> None:
         )
 
 
-def get_unit_id_type_for_unit_type(unit_id: str) -> Union[str, None]:
+def get_unit_id_type_for_unit_type(
+    unit_id: UnitType,
+) -> Union[str, UnitIdType]:
     """
     Returns the unitIdType for the supplied unitType. Returns None
     if supplied unitType has no attached unitIdType.

--- a/microdata_tools/validation/components/unit_id_types.py
+++ b/microdata_tools/validation/components/unit_id_types.py
@@ -1,25 +1,26 @@
 from typing import Union
 
 from microdata_tools.validation.exceptions import UnregisteredUnitTypeError
+from microdata_tools.validation.model.metadata import UnitType, UnitIdType
 
 # When updating this dictionary remember to also
 # update the Metadata model with the
 # same key value in the enum for unitType
 UNIT_ID_TYPE_FOR_UNIT_TYPE = {
-    "JOBB": "JOBBID_1",
-    "KJORETOY": "KJORETOY_ID",
-    "FAMILIE": "FNR",
-    "FORETAK": "ORGNR",
-    "HUSHOLDNING": "FNR",
-    "KOMMUNE": None,
-    "KURS": "KURSID",
-    "PERSON": "FNR",
-    "VIRKSOMHET": "ORGNR",
-    "BK_HELSESTASJONSKONSULTASJON": "BK_STASJONS_BESOKS_ID",
+    UnitType.JOBB: UnitIdType.JOBBID_1,
+    UnitType.KJORETOY: UnitIdType.KJORETOY_ID,
+    UnitType.FAMILIE: UnitIdType.FNR,
+    UnitType.FORETAK: UnitIdType.ORGNR,
+    UnitType.HUSHOLDNING: UnitIdType.FNR,
+    UnitType.KOMMUNE: None,
+    UnitType.KURS: UnitIdType.KURSID,
+    UnitType.PERSON: UnitIdType.FNR,
+    UnitType.VIRKSOMHET: UnitIdType.ORGNR,
+    UnitType.BK_HELSESTASJONSKONSULTASJON: None,
 }
 
 
-def get(unit_type: str) -> Union[str, None]:
+def get(unit_type: UnitType) -> Union[UnitIdType, None]:
     try:
         return UNIT_ID_TYPE_FOR_UNIT_TYPE[unit_type]
     except KeyError as e:

--- a/microdata_tools/validation/model/metadata.py
+++ b/microdata_tools/validation/model/metadata.py
@@ -46,6 +46,15 @@ class UnitType(str, Enum):
     BK_HELSESTASJONSKONSULTASJON = "BK_HELSESTASJONSKONSULTASJON"
 
 
+class UnitIdType(str, Enum):
+    JOBBID_1 = "JOBBID_1"
+    KJORETOY_ID = "KJORETOY_ID"
+    FNR = "FNR"
+    ORGNR = "ORGNR"
+    KURSID = "KURSID"
+    BK_STASJONS_BESOKS_ID = "BK_STASJONS_BESOKS_ID"
+
+
 class MultiLingualString(BaseModel):
     languageCode: LanguageCode
     value: str
@@ -96,7 +105,9 @@ class SentinelItem(BaseModel, extra=Extra.forbid):
 class ValueDomain(BaseModel, extra=Extra.forbid):
     description: Optional[conlist(MultiLingualString, min_items=1)]
     measurementType: Optional[str]
-    measurementUnitDescription: Optional[conlist(MultiLingualString, min_items=1)]
+    measurementUnitDescription: Optional[
+        conlist(MultiLingualString, min_items=1)
+    ]
     uriDefinition: Optional[List[Union[str, None]]]
     codeList: Optional[conlist(CodeListItem, min_items=1)]
     sentinelAndMissingValues: Optional[List[SentinelItem]]
@@ -124,7 +135,8 @@ class ValueDomain(BaseModel, extra=Extra.forbid):
                 )
         else:
             raise ValueError(
-                "A valueDomain must contain either a codeList " "or a description"
+                "A valueDomain must contain either a codeList "
+                "or a description"
             )
         return values
 
@@ -164,8 +176,12 @@ class Metadata(BaseModel):
     temporalityType: TemporalityType
     sensitivityLevel: SensitivityLevel
     populationDescription: conlist(MultiLingualString, min_items=1)
-    spatialCoverageDescription: Optional[conlist(MultiLingualString, min_items=1)]
-    subjectFields: conlist(conlist(MultiLingualString, min_items=1), min_items=1)
+    spatialCoverageDescription: Optional[
+        conlist(MultiLingualString, min_items=1)
+    ]
+    subjectFields: conlist(
+        conlist(MultiLingualString, min_items=1), min_items=1
+    )
     dataRevision: DataRevision
     identifierVariables: conlist(IdentifierVariable, min_items=1, max_items=1)
     measureVariables: conlist(MeasureVariable, min_items=1, max_items=1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "microdata-tools"
-version = "0.7.0"
+version = "0.7.1"
 description = "Tools for the microdata.no platform"
 authors = ["microdata-developers"]
 license = "MIT License"

--- a/tests/test_validation/test_get_unit_id_type_for_unit_type.py
+++ b/tests/test_validation/test_get_unit_id_type_for_unit_type.py
@@ -2,13 +2,20 @@ import pytest
 
 from microdata_tools import get_unit_id_type_for_unit_type
 from microdata_tools.validation.exceptions import UnregisteredUnitTypeError
+from microdata_tools.validation.model.metadata import UnitType, UnitIdType
 
 
 def test_get_unit_id_type_for_unit_type():
-    assert "FNR" == get_unit_id_type_for_unit_type("PERSON")
-    assert "FNR" == get_unit_id_type_for_unit_type("FAMILIE")
-    assert "ORGNR" == get_unit_id_type_for_unit_type("VIRKSOMHET")
-    assert get_unit_id_type_for_unit_type("KOMMUNE") is None
+    assert UnitIdType.FNR == get_unit_id_type_for_unit_type(UnitType.PERSON)
+    assert UnitIdType.FNR == get_unit_id_type_for_unit_type(UnitType.FAMILIE)
+    assert UnitIdType.ORGNR == get_unit_id_type_for_unit_type(
+        UnitType.VIRKSOMHET
+    )
+    assert get_unit_id_type_for_unit_type(UnitType.KOMMUNE) is None
+    assert (
+        get_unit_id_type_for_unit_type(UnitType.BK_HELSESTASJONSKONSULTASJON)
+        is None
+    )
 
     with pytest.raises(UnregisteredUnitTypeError) as e:
         get_unit_id_type_for_unit_type("NOT A UNIT TYPE")


### PR DESCRIPTION
### Overview

- Created "UnitIdType" enum
- Replaced str with UnitType and UnitIdType where its used
- Updated tests to ensure mapping between UnitType and UnitIdType  
- Set UnitIdType for  "BK_HELSESTASJONSKONSULTASJON" to None