### PR TITLE
Bugfix cleanup

### DIFF
--- a/microdata_tools/validation/__init__.py
+++ b/microdata_tools/validation/__init__.py
@@ -55,6 +55,8 @@ def validate_dataset(
     If the dataset is valid, the list will be empty.
     """
     data_errors = []
+    working_directory_path = None
+
     try:
         _validate_dataset_name(dataset_name)
         (
@@ -111,7 +113,7 @@ def validate_dataset(
         raise e
     finally:
         # Delete temporary files
-        if not keep_temporary_files:
+        if not keep_temporary_files and working_directory_path:
             local_storage.clean_up_temporary_files(
                 dataset_name,
                 working_directory_path,
@@ -131,6 +133,8 @@ def validate_metadata(
     If the metadata is valid, the list will be empty.
     """
     data_errors = []
+    working_directory_path = None
+
     try:
         _validate_dataset_name(dataset_name)
         (
@@ -153,7 +157,7 @@ def validate_metadata(
         raise e
     finally:
         # Delete temporary files
-        if not keep_temporary_files:
+        if not keep_temporary_files and working_directory_path:
             local_storage.clean_up_temporary_files(
                 dataset_name,
                 working_directory_path,

--- a/microdata_tools/validation/adapter/local_storage.py
+++ b/microdata_tools/validation/adapter/local_storage.py
@@ -24,7 +24,9 @@ def write_json(filepath: Path, content: dict) -> None:
         json.dump(content, json_file, indent=4, ensure_ascii=False)
 
 
-def resolve_working_directory(working_directory: Union[str, None]) -> Tuple[Path, bool]:
+def resolve_working_directory(
+    working_directory: Union[str, None]
+) -> Tuple[Path, bool]:
     """
     Generates a working directory if a working directory is not supplied.
     Returns a tuple with:
@@ -61,21 +63,24 @@ def clean_up_temporary_files(
                     "An exception occured while attempting to delete"
                     f"temporary files: {e}"
                 )
+                raise e
         else:
             for file in generated_files:
                 try:
                     os.remove(working_directory / file)
-                except FileNotFoundError:
+                except FileNotFoundError as e:
                     logger.error(
                         f"Could not find file {file} in working directory "
                         "when attempting to delete temporary files."
                     )
+                    raise e
     else:
         for file in generated_files:
             try:
                 os.remove(working_directory / file)
-            except FileNotFoundError:
+            except FileNotFoundError as e:
                 logger.error(
                     f"Could not find file {file} in working directory "
                     "when attempting to delete temporary files."
                 )
+                raise e

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "microdata-tools"
-version = "0.7.2"
+version = "0.7.3"
 description = "Tools for the microdata.no platform"
 authors = ["microdata-developers"]
 license = "MIT License"

--- a/tests/test_validation/test_validate_dataset.py
+++ b/tests/test_validation/test_validate_dataset.py
@@ -48,6 +48,17 @@ def test_validate_valid_dataset():
         assert actual_metadata == expected_metadata
 
 
+def test_invalid_dataset_name():
+    data_errors = validate_dataset(
+        "1_INVALID_DATASET_NAME",
+        input_directory=INPUT_DIR,
+    )
+    assert data_errors == [
+        '"1_INVALID_DATASET_NAME" contains invalid characters. '
+        'Please use only uppercase A-Z, numbers 0-9 or "_"'
+    ]
+
+
 def test_validate_valid_dataset_delete_temporary_files():
     for valid_dataset_name in VALID_DATASET_NAMES:
         data_errors = validate_dataset(

--- a/tests/test_validation/test_validate_metadata.py
+++ b/tests/test_validation/test_validate_metadata.py
@@ -52,6 +52,17 @@ def test_validate_invalid_metadata():
     assert "field required" in data_errors[0]
 
 
+def test_invalid_dataset_name():
+    data_errors = validate_metadata(
+        "1_INVALID_DATASET_NAME",
+        input_directory=INPUT_DIR,
+    )
+    assert data_errors == [
+        '"1_INVALID_DATASET_NAME" contains invalid characters. '
+        'Please use only uppercase A-Z, numbers 0-9 or "_"'
+    ]
+
+
 def test_validate_metadata_does_not_exist():
     with pytest.raises(FileNotFoundError):
         validate_metadata(NO_SUCH_METADATA, INPUT_DIR)


### PR DESCRIPTION
# BUGFIX CLEANUP

### What's changed?
* When a validation error happened before working directory was generated (dataset name invalid); The finally clause is unable to delete a non existent working directory.
* Raising errors with cleaning up after a validation to the user so it is easier to report problems. There might be a common error that has not yet been reported.
* bumped version 0.7.2 => 0.7.3 (PATCH)