### PR TITLE
Fix unit types and read

### DIFF
--- a/microdata_tools/validation/__init__.py
+++ b/microdata_tools/validation/__init__.py
@@ -72,6 +72,9 @@ def validate_dataset(
             dataset_name, input_metadata_path
         )
         measure_data_type = metadata_dict["measureVariables"][0]["dataType"]
+        identifier_data_type = metadata_dict["identifierVariables"][0][
+            "dataType"
+        ]
         temporality_type = metadata_dict["temporalityType"]
         code_list = metadata_dict["measureVariables"][0]["valueDomain"].get(
             "codeList"
@@ -82,7 +85,10 @@ def validate_dataset(
 
         # Read data
         table = data_reader.read_and_sanitize_csv(
-            input_data_path, measure_data_type, temporality_type
+            input_data_path,
+            identifier_data_type,
+            measure_data_type,
+            temporality_type,
         )
 
         # Enrich metadata with temporal data

--- a/microdata_tools/validation/components/unit_type_variables/BK_HELSESTASJONSKONSULTASJON.json
+++ b/microdata_tools/validation/components/unit_type_variables/BK_HELSESTASJONSKONSULTASJON.json
@@ -45,16 +45,15 @@
         }
       ]
     },
-    "format": "RandomUInt48",
     "valueDomain": {
       "description": [
         {
           "languageCode": "no",
-          "value": "Pseudonymisert helsestasjonskonsultasjonbesøksid"
+          "value": "helsestasjonskonsultasjonbesøksid"
         },
         {
           "languageCode": "en",
-          "value": "Pseudonymized healt center visit id"
+          "value": "health center visit id"
         }
       ]
     }

--- a/microdata_tools/validation/components/unit_type_variables/FAMILIE.json
+++ b/microdata_tools/validation/components/unit_type_variables/FAMILIE.json
@@ -20,7 +20,7 @@
       "value": "Identifier for family in microdata"
     }
   ],
-  "dataType": "LONG",
+  "dataType": "STRING",
   "unitType": {
     "shortName": "FAMILIE",
     "requiresPseudonymization": true,

--- a/microdata_tools/validation/components/unit_type_variables/FORETAK.json
+++ b/microdata_tools/validation/components/unit_type_variables/FORETAK.json
@@ -20,7 +20,7 @@
       "value": "Identifier for enterprise in microdata"
     }
   ],
-  "dataType": "LONG",
+  "dataType": "STRING",
   "unitType": {
     "shortName": "FORETAK",
     "requiresPseudonymization": true,

--- a/microdata_tools/validation/components/unit_type_variables/HKDIR_STUDIESOKNAD.json
+++ b/microdata_tools/validation/components/unit_type_variables/HKDIR_STUDIESOKNAD.json
@@ -20,7 +20,7 @@
         "value": "Identifier for admission application"
       }
     ],
-    "dataType": "LONG",
+    "dataType": "STRING",
     "unitType": {
       "shortName": "HKDIR_STUDIESOKNAD",
       "requiresPseudonymization": true,

--- a/microdata_tools/validation/components/unit_type_variables/HUSHOLDNING.json
+++ b/microdata_tools/validation/components/unit_type_variables/HUSHOLDNING.json
@@ -20,7 +20,7 @@
       "value": "Identifier for household in microdata"
     }
   ],
-  "dataType": "LONG",
+  "dataType": "STRING",
   "unitType": {
     "requiresPseudonymization": true,
     "shortName": "HUSHOLDNING",

--- a/microdata_tools/validation/components/unit_type_variables/JOBB.json
+++ b/microdata_tools/validation/components/unit_type_variables/JOBB.json
@@ -20,7 +20,7 @@
       "value": "Identifier for job in microdata"
     }
   ],
-  "dataType": "LONG",
+  "dataType": "STRING",
   "unitType": {
     "requiresPseudonymization": true,
     "shortName": "JOBB",

--- a/microdata_tools/validation/components/unit_type_variables/KJORETOY.json
+++ b/microdata_tools/validation/components/unit_type_variables/KJORETOY.json
@@ -20,7 +20,7 @@
       "value": "Identifier for vehicles in microdata"
     }
   ],
-  "dataType": "LONG",
+  "dataType": "STRING",
   "unitType": {
     "requiresPseudonymization": true,
     "shortName": "KJORETOY",

--- a/microdata_tools/validation/components/unit_type_variables/KURS.json
+++ b/microdata_tools/validation/components/unit_type_variables/KURS.json
@@ -20,7 +20,7 @@
       "value": "Identifier for course in microdata"
     }
   ],
-  "dataType": "LONG",
+  "dataType": "STRING",
   "unitType": {
     "requiresPseudonymization": true,
     "shortName": "KURS",

--- a/microdata_tools/validation/components/unit_type_variables/NPR_EPISODE.json
+++ b/microdata_tools/validation/components/unit_type_variables/NPR_EPISODE.json
@@ -20,7 +20,7 @@
         "value": "Identifier for NPR episode"
       }
     ],
-    "dataType": "LONG",
+    "dataType": "STRING",
     "unitType": {
       "shortName": "NPR_EPISODE",
       "requiresPseudonymization": true,

--- a/microdata_tools/validation/components/unit_type_variables/PERSON.json
+++ b/microdata_tools/validation/components/unit_type_variables/PERSON.json
@@ -20,7 +20,7 @@
       "value": "Identifier for person in microdata"
     }
   ],
-  "dataType": "LONG",
+  "dataType": "STRING",
   "unitType": {
     "shortName": "PERSON",
     "requiresPseudonymization": true,

--- a/microdata_tools/validation/components/unit_type_variables/VIRKSOMHET.json
+++ b/microdata_tools/validation/components/unit_type_variables/VIRKSOMHET.json
@@ -20,7 +20,7 @@
       "value": "Identifier for establishment in microdata"
     }
   ],
-  "dataType": "LONG",
+  "dataType": "STRING",
   "unitType": {
     "requiresPseudonymization": true,
     "shortName": "VIRKSOMHET",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "microdata-tools"
-version = "0.7.3"
+version = "0.8.0"
 description = "Tools for the microdata.no platform"
 authors = ["microdata-developers"]
 license = "MIT License"

--- a/tests/resources/validation/validate_dataset/expected/SYNT_BEFOLKNING_SIVSTAND.json
+++ b/tests/resources/validation/validate_dataset/expected/SYNT_BEFOLKNING_SIVSTAND.json
@@ -56,7 +56,7 @@
           "value": "Identifier for person in microdata"
         }
       ],
-      "dataType": "LONG",
+      "dataType": "STRING",
       "unitType": {
         "shortName": "PERSON",
         "requiresPseudonymization": true,

--- a/tests/resources/validation/validate_dataset/expected/SYNT_PERSON_INNTEKT.json
+++ b/tests/resources/validation/validate_dataset/expected/SYNT_PERSON_INNTEKT.json
@@ -62,7 +62,7 @@
           "value": "Identifier for person in microdata"
         }
       ],
-      "dataType": "LONG",
+      "dataType": "STRING",
       "unitType": {
         "shortName": "PERSON",
         "requiresPseudonymization": true,

--- a/tests/resources/validation/validate_dataset/expected/SYNT_PERSON_MOR.json
+++ b/tests/resources/validation/validate_dataset/expected/SYNT_PERSON_MOR.json
@@ -56,7 +56,7 @@
           "value": "Identifier for person in microdata"
         }
       ],
-      "dataType": "LONG",
+      "dataType": "STRING",
       "unitType": {
         "shortName": "PERSON",
         "requiresPseudonymization": true,
@@ -111,7 +111,7 @@
           "value": "Fødselsnummer til personens biologiske mor"
         }
       ],
-      "dataType": "LONG",
+      "dataType": "STRING",
       "unitType": {
         "shortName": "PERSON",
         "requiresPseudonymization": true,

--- a/tests/resources/validation/validate_dataset/expected/SYNT_UTDANNING.json
+++ b/tests/resources/validation/validate_dataset/expected/SYNT_UTDANNING.json
@@ -62,7 +62,7 @@
           "value": "Identifier for person in microdata"
         }
       ],
-      "dataType": "LONG",
+      "dataType": "STRING",
       "unitType": {
         "shortName": "PERSON",
         "requiresPseudonymization": true,

--- a/tests/resources/validation/validate_metadata/expected/SYNT_BEFOLKNING_SIVSTAND.json
+++ b/tests/resources/validation/validate_metadata/expected/SYNT_BEFOLKNING_SIVSTAND.json
@@ -53,7 +53,7 @@
           "value": "Identifier for person in microdata"
         }
       ],
-      "dataType": "LONG",
+      "dataType": "STRING",
       "unitType": {
         "shortName": "PERSON",
         "requiresPseudonymization": true,

--- a/tests/resources/validation/validate_metadata/expected/SYNT_PERSON_INNTEKT.json
+++ b/tests/resources/validation/validate_metadata/expected/SYNT_PERSON_INNTEKT.json
@@ -59,7 +59,7 @@
           "value": "Identifier for person in microdata"
         }
       ],
-      "dataType": "LONG",
+      "dataType": "STRING",
       "unitType": {
         "shortName": "PERSON",
         "requiresPseudonymization": true,

--- a/tests/test_validation/steps/test_data_reader.py
+++ b/tests/test_validation/steps/test_data_reader.py
@@ -73,7 +73,7 @@ def test_get_temporal_data():
 def test_sanitize_long():
     long_data_path = INPUT_DIR / "LONG.csv"
     assert data_reader.read_and_sanitize_csv(
-        long_data_path, "LONG", "FIXED"
+        long_data_path, "STRING", "LONG", "FIXED"
     ).to_pydict() == {
         **EXPECTED_COLUMNS,
         "value": [12345, 12345, 12345],
@@ -81,7 +81,7 @@ def test_sanitize_long():
     with pytest.raises(ValidationError) as e:
         invalid_data_path = INPUT_DIR / "LONG_INVALID_VALUE.csv"
         assert data_reader.read_and_sanitize_csv(
-            invalid_data_path, "LONG", "FIXED"
+            invalid_data_path, "STRING", "LONG", "FIXED"
         )
     assert e.value.errors == [
         "In CSV column #1: CSV conversion error to int64: invalid value 'abc123'"
@@ -91,7 +91,7 @@ def test_sanitize_long():
 def test_sanitize_double():
     double_data_path = INPUT_DIR / "DOUBLE.csv"
     assert data_reader.read_and_sanitize_csv(
-        double_data_path, "DOUBLE", "FIXED"
+        double_data_path, "STRING", "DOUBLE", "FIXED"
     ).to_pydict() == {
         **EXPECTED_COLUMNS,
         "value": [12345.12345, 12345.12345, 12345.12345],
@@ -99,7 +99,7 @@ def test_sanitize_double():
     with pytest.raises(ValidationError) as e:
         invalid_data_path = INPUT_DIR / "DOUBLE_INVALID_FORMAT.csv"
         assert data_reader.read_and_sanitize_csv(
-            invalid_data_path, "DOUBLE", "FIXED"
+            invalid_data_path, "STRING", "DOUBLE", "FIXED"
         )
     assert e.value.errors == [
         "In CSV column #1: CSV conversion error to double: invalid value "
@@ -110,7 +110,7 @@ def test_sanitize_double():
 def test_sanitize_date():
     date_data_path = INPUT_DIR / "DATE.csv"
     assert data_reader.read_and_sanitize_csv(
-        date_data_path, "DATE", "FIXED"
+        date_data_path, "STRING", "DATE", "FIXED"
     ).to_pydict() == {
         **EXPECTED_COLUMNS,
         "value": [18262, 18262, 18262],
@@ -118,7 +118,7 @@ def test_sanitize_date():
     with pytest.raises(ValidationError) as e:
         invalid_data_path = INPUT_DIR / "DATE_INVALID_VALUE.csv"
         assert data_reader.read_and_sanitize_csv(
-            invalid_data_path, "DATE", "FIXED"
+            invalid_data_path, "STRING", "DATE", "FIXED"
         )
     assert e.value.errors == [
         "In CSV column #1: CSV conversion error to date32[day]: invalid value "
@@ -129,7 +129,7 @@ def test_sanitize_date():
 def test_sanitize_string():
     string_data_path = INPUT_DIR / "STRING.csv"
     assert data_reader.read_and_sanitize_csv(
-        string_data_path, "STRING", "FIXED"
+        string_data_path, "STRING", "STRING", "FIXED"
     ).to_pydict() == {
         **EXPECTED_COLUMNS,
         "value": ["abc123", "abc123", "abc123"],
@@ -140,7 +140,7 @@ def test_sanitize_data_invalid_start_stop():
     with pytest.raises(ValidationError) as e:
         invalid_data_path = INPUT_DIR / "STRING_INVALID_START_STOP.csv"
         assert data_reader.read_and_sanitize_csv(
-            invalid_data_path, "STRING", "FIXED"
+            invalid_data_path, "STRING", "STRING", "FIXED"
         )
     assert e.value.errors == [
         "In CSV column #3: CSV conversion error to date32[day]: invalid value "
@@ -152,7 +152,7 @@ def test_sanitize_data_wrong_delimiter():
     with pytest.raises(ValidationError) as e:
         invalid_data_path = INPUT_DIR / "STRING_INVALID_DELIMITER.csv"
         assert data_reader.read_and_sanitize_csv(
-            invalid_data_path, "STRING", "FIXED"
+            invalid_data_path, "STRING", "STRING", "FIXED"
         )
     assert e.value.errors == [
         "CSV parse error: Expected 5 columns, got 1: 000001,abc123,2020-01-01,"
@@ -163,7 +163,7 @@ def test_sanitize_data_empty_file():
     with pytest.raises(ValidationError) as e:
         invalid_data_path = INPUT_DIR / "STRING_EMPTY_FILE.csv"
         assert data_reader.read_and_sanitize_csv(
-            invalid_data_path, "STRING", "FIXED"
+            invalid_data_path, "STRING", "STRING", "FIXED"
         )
     assert e.value.errors == ["Empty CSV file"]
 
@@ -176,7 +176,7 @@ def test_sanitize_data_start_year():
     }
     status_data_path = INPUT_DIR / "STRING_STATUS.csv"
     assert data_reader.read_and_sanitize_csv(
-        status_data_path, "STRING", "STATUS"
+        status_data_path, "STRING", "STRING", "STATUS"
     ).to_pydict() == {
         **expected_columns,
         "start_epoch_days": [17897, 18262, 18262],
@@ -184,7 +184,7 @@ def test_sanitize_data_start_year():
     }
     accumulated_data_path = INPUT_DIR / "STRING_ACCUMULATED.csv"
     assert data_reader.read_and_sanitize_csv(
-        accumulated_data_path, "STRING", "ACCUMULATED"
+        accumulated_data_path, "STRING", "STRING", "ACCUMULATED"
     ).to_pydict() == {
         **expected_columns,
         "start_epoch_days": [17897, 18262, 18262],


### PR DESCRIPTION
# FIX UNIT TYPES AND DATA READER

### What's changed?
- Updated central definitions of unit type variables
  - All pseudonymized variables have input type string
  - BK_ variable is not pseudonymized and a LONG
- Update the reader to take in indentifier data type from the central definitions
- Update tests to reflect change

### What's next?
- Update job-executor to include this change and transform the metadata definition of the datatype if a variable is to be pseudonymized