### PR TITLE
Validate file names

### DIFF
--- a/microdata_tools/validation/__init__.py
+++ b/microdata_tools/validation/__init__.py
@@ -56,6 +56,7 @@ def validate_dataset(
     """
     data_errors = []
     working_directory_path = None
+    working_directory_was_generated = False
 
     try:
         _validate_dataset_name(dataset_name)
@@ -140,6 +141,7 @@ def validate_metadata(
     """
     data_errors = []
     working_directory_path = None
+    working_directory_was_generated = False
 
     try:
         _validate_dataset_name(dataset_name)

--- a/microdata_tools/validation/__init__.py
+++ b/microdata_tools/validation/__init__.py
@@ -59,6 +59,7 @@ def validate_dataset(
 
     try:
         _validate_dataset_name(dataset_name)
+        local_storage.validate_dataset_dir(Path(input_directory), dataset_name)
         (
             working_directory_path,
             working_directory_was_generated,
@@ -66,7 +67,6 @@ def validate_dataset(
         input_dataset_directory = Path(input_directory) / dataset_name
         input_metadata_path = input_dataset_directory / f"{dataset_name}.json"
         input_data_path = input_dataset_directory / f"{dataset_name}.csv"
-
         # Read and validate metadata
         metadata_dict = metadata_reader.run_reader(
             dataset_name, input_metadata_path
@@ -143,6 +143,9 @@ def validate_metadata(
 
     try:
         _validate_dataset_name(dataset_name)
+        local_storage.validate_dataset_dir(
+            Path(input_directory), dataset_name, require_csv=False
+        )
         (
             working_directory_path,
             working_directory_was_generated,

--- a/microdata_tools/validation/adapter/local_storage.py
+++ b/microdata_tools/validation/adapter/local_storage.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from typing import Tuple, Union
 import uuid
 
+from microdata_tools.validation.exceptions import ValidationError
+
 
 logger = logging.getLogger()
 
@@ -22,6 +24,25 @@ def load_json(filepath: Path) -> dict:
 def write_json(filepath: Path, content: dict) -> None:
     with open(filepath, "w", encoding="utf-8") as json_file:
         json.dump(content, json_file, indent=4, ensure_ascii=False)
+
+
+def validate_dataset_dir(
+    input_dir: Path, dataset_name: str, require_csv: bool = True
+) -> None:
+    dataset_dir = input_dir / dataset_name
+    if require_csv:
+        if not os.path.exists(dataset_dir / f"{dataset_name}.csv"):
+            raise ValidationError(
+                f"Could not find {dataset_name}.csv in working directory",
+                errors=[
+                    "Could not find {dataset_name}.csv in working directory"
+                ],
+            )
+    if not os.path.exists(dataset_dir / f"{dataset_name}.json"):
+        raise ValidationError(
+            f"Could not find {dataset_name}.json in working directory",
+            errors=["Could not find {dataset_name}.json in working directory"],
+        )
 
 
 def resolve_working_directory(
@@ -44,7 +65,7 @@ def resolve_working_directory(
 def clean_up_temporary_files(
     dataset_name: str,
     working_directory: Path,
-    delete_working_directory: Path = False,
+    delete_working_directory: bool = False,
 ):
     generated_files = [
         f"{dataset_name}.parquet",

--- a/microdata_tools/validation/adapter/local_storage.py
+++ b/microdata_tools/validation/adapter/local_storage.py
@@ -30,6 +30,11 @@ def validate_dataset_dir(
     input_dir: Path, dataset_name: str, require_csv: bool = True
 ) -> None:
     dataset_dir = input_dir / dataset_name
+    if not dataset_dir.exists():
+        raise ValidationError(
+            f"Dataset directory {dataset_dir} not found",
+            errors=[f"Dataset directory {dataset_dir} not found"],
+        )
     if require_csv:
         if not os.path.exists(dataset_dir / f"{dataset_name}.csv"):
             raise ValidationError(
@@ -60,6 +65,9 @@ def resolve_working_directory(
         generated_working_directory = Path(str(uuid.uuid4()))
         os.mkdir(generated_working_directory)
         return generated_working_directory, True
+
+
+logger.warning("This function will be deprecated in a future release")
 
 
 def clean_up_temporary_files(

--- a/microdata_tools/validation/adapter/local_storage.py
+++ b/microdata_tools/validation/adapter/local_storage.py
@@ -67,9 +67,6 @@ def resolve_working_directory(
         return generated_working_directory, True
 
 
-logger.warning("This function will be deprecated in a future release")
-
-
 def clean_up_temporary_files(
     dataset_name: str,
     working_directory: Path,

--- a/poetry.lock
+++ b/poetry.lock
@@ -340,13 +340,13 @@ files = [
 
 [[package]]
 name = "platformdirs"
-version = "3.11.0"
+version = "4.0.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "platformdirs-3.11.0-py3-none-any.whl", hash = "sha256:e9d171d00af68be50e9202731309c4e658fd8bc76f55c11c7dd760d023bda68e"},
-    {file = "platformdirs-3.11.0.tar.gz", hash = "sha256:cf8ee52a3afdb965072dcc652433e0c7e3e40cf5ea1477cd4b3b1d2eb75495b3"},
+    {file = "platformdirs-4.0.0-py3-none-any.whl", hash = "sha256:118c954d7e949b35437270383a3f2531e99dd93cf7ce4dc8340d3356d30f173b"},
+    {file = "platformdirs-4.0.0.tar.gz", hash = "sha256:cb633b2bcf10c51af60beb0ab06d2f1d69064b43abf4c185ca6b28865f3f9731"},
 ]
 
 [package.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "microdata-tools"
-version = "0.9.1"
+version = "0.9.2"
 description = "Tools for the microdata.no platform"
 authors = ["microdata-developers"]
 license = "MIT License"

--- a/tests/test_validation/test_validate_dataset.py
+++ b/tests/test_validation/test_validate_dataset.py
@@ -97,12 +97,13 @@ def test_validate_valid_dataset_delete_working_files():
 
 
 def test_dataset_does_not_exist():
-    with pytest.raises(FileNotFoundError):
-        validate_dataset(
-            NO_SUCH_DATASET_NAME,
-            working_directory=WORKING_DIR,
-            input_directory=INPUT_DIR,
-        )
+    data_errors = validate_dataset(
+        NO_SUCH_DATASET_NAME,
+        working_directory=WORKING_DIR,
+        input_directory=INPUT_DIR,
+    )
+    assert len(data_errors) == 1
+    assert "not found" in data_errors[0]
 
 
 def get_working_directory_files() -> list:

--- a/tests/test_validation/test_validate_metadata.py
+++ b/tests/test_validation/test_validate_metadata.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from microdata_tools import validate_metadata
+from microdata_tools.validation.exceptions import ValidationError
 
 
 logger = logging.getLogger()
@@ -64,8 +65,9 @@ def test_invalid_dataset_name():
 
 
 def test_validate_metadata_does_not_exist():
-    with pytest.raises(FileNotFoundError):
-        validate_metadata(NO_SUCH_METADATA, INPUT_DIR)
+    data_errors = validate_metadata(NO_SUCH_METADATA, INPUT_DIR)
+    assert len(data_errors) == 1
+    assert "not found" in data_errors[0]
 
 
 def get_working_directory_files() -> list:


### PR DESCRIPTION
Validate filenames more explicitly and return a validation error like the rest of the validation results.
Fixed some minor bugs where variables could end up not being declare before the finally clause