### PR TITLE
Better response timespan error

### DIFF
--- a/microdata_tools/validation/steps/data_reader.py
+++ b/microdata_tools/validation/steps/data_reader.py
@@ -161,6 +161,12 @@ def get_temporal_data(
     temporal_data = {}
     if temporality_type == "FIXED":
         stop_max = compute.max(table["stop_epoch_days"]).as_py()
+        if stop_max is None:
+            error_string = (
+                "Could not read data in fourth column (Stop date)."
+                " Is this column empty?"
+            )
+            raise ValidationError(error_string, errors=[error_string])
         temporal_data["start"] = "1900-01-01"
         temporal_data["latest"] = (
             datetime(1970, 1, 1) + timedelta(days=stop_max)
@@ -172,6 +178,18 @@ def get_temporal_data(
         stop_min, stop_max = (
             compute.min_max(table["stop_epoch_days"]).as_py().values()
         )
+        if start_min is None or stop_min is None:
+            error_string = (
+                "Could not read data in third column (Start date)."
+                " Is this column empty?"
+            )
+            raise ValidationError(error_string, errors=[error_string])
+        if stop_min is None or stop_max is None:
+            error_string = (
+                "Could not read data in fourth column (Stop date)."
+                " Is this column empty?"
+            )
+            raise ValidationError(error_string, errors=[error_string])
         min_date = min(
             [date for date in [start_min, stop_min] if date is not None]
         )

--- a/microdata_tools/validation/steps/data_reader.py
+++ b/microdata_tools/validation/steps/data_reader.py
@@ -178,7 +178,7 @@ def get_temporal_data(
         stop_min, stop_max = (
             compute.min_max(table["stop_epoch_days"]).as_py().values()
         )
-        if start_min is None or stop_min is None:
+        if start_min is None or start_max is None:
             error_string = (
                 "Could not read data in third column (Start date)."
                 " Is this column empty?"

--- a/poetry.lock
+++ b/poetry.lock
@@ -245,13 +245,13 @@ test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "exceptiongroup"
-version = "1.1.3"
+version = "1.2.0"
 description = "Backport of PEP 654 (exception groups)"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "exceptiongroup-1.1.3-py3-none-any.whl", hash = "sha256:343280667a4585d195ca1cf9cef84a4e178c4b6cf2274caef9859782b567d5e3"},
-    {file = "exceptiongroup-1.1.3.tar.gz", hash = "sha256:097acd85d473d75af5bb98e41b61ff7fe35efe6675e4f9370ec6ec5126d160e9"},
+    {file = "exceptiongroup-1.2.0-py3-none-any.whl", hash = "sha256:4bfd3996ac73b41e9b9628b04e079f193850720ea5945fc96a08633c66912f14"},
+    {file = "exceptiongroup-1.2.0.tar.gz", hash = "sha256:91f5c769735f051a4290d52edd0858999b57e5876e9f85937691bd4c9fa3ed68"},
 ]
 
 [package.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "microdata-tools"
-version = "0.11.1"
+version = "0.11.2"
 description = "Tools for the microdata.no platform"
 authors = ["microdata-developers"]
 license = "MIT License"

--- a/tests/test_validation/steps/test_data_reader.py
+++ b/tests/test_validation/steps/test_data_reader.py
@@ -39,6 +39,11 @@ def test_get_temporal_data():
         "start_epoch_days": [1, 2, 3, 4, 5],
         "stop_epoch_days": [1, 2, 3, 4, 5],
     }
+    empty_table = {
+        "start_epoch_days": [None, None, None, None, None],
+        "stop_epoch_days": [None, None, None, None, None],
+    }
+
     fixed_table = pyarrow.Table.from_pydict(fixed_dict, schema=table_schema)
     assert data_reader.get_temporal_data(fixed_table, "FIXED") == {
         "start": "1900-01-01",
@@ -68,6 +73,11 @@ def test_get_temporal_data():
             "1970-01-06",
         ],
     }
+    with pytest.raises(ValidationError) as e:
+        data_reader.get_temporal_data(empty_table, "EVENT")
+    assert e.value.errors == [
+        "Could not read data in third column (Start date). Is this column empty?"
+    ]
 
 
 def test_sanitize_long():


### PR DESCRIPTION
if the stop date column is empty for a FIXED dataset, or either start or stop columns are empty for any other temporality the compute.min_max will return None-values. This happens before the validation steps are ran so we got this value from python when doing a min(...):
```
min() arg is an empty sequence
```

And passed this value directly to the user. Catching the error now and returning a more sensible errormessage