### PR TITLE
turn_off_threads_in_gb: new param

### DIFF
--- a/microdata_tools/validation/steps/dataset_validator.py
+++ b/microdata_tools/validation/steps/dataset_validator.py
@@ -304,7 +304,7 @@ def _no_overlapping_timespans_check(data: FileSystemDataset):
             [("start_epoch_days", "ascending")]
         )
         identifier_time_spans = identifier_time_spans.group_by(
-            "unit_id"
+            "unit_id", use_threads=False
         ).aggregate(
             [("start_epoch_days", "list"), ("stop_epoch_days", "list")]
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "microdata-tools"
-version = "0.11.5"
+version = "0.11.6"
 description = "Tools for the microdata.no platform"
 authors = ["microdata-developers"]
 license = "MIT License"


### PR DESCRIPTION
Avoid using threads in group_by statements as they break ordering
ref: https://arrow.apache.org/release/14.0.0.html

> [GH-36709](https://github.com/apache/arrow/issues/36709) - [Python] Allow to specify use_threads=False in Table.group_by to have stable ordering (#36768)

>GH-36709: That should have been fully equivalent, but now I see that the TableGroupBy helper was having a default of bool use_threads = false in its header file, while in the new python code we are doing decl.to_table(use_threads=True).
So that will probably explain the difference in behaviour: in 12.0, the group_by method was not yet running in parallel, while now it is.