### PR TITLE
Bigger data tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,7 +51,7 @@ stages:
       - script: python -m poetry install
         displayName: 'Install dependencies'
         
-      - script: python -m poetry run python -m pytest
+      - script: python -m poetry run python -m pytest --include-big-data
         displayName: 'Test with pytest'
 
 - stage: build

--- a/poetry.lock
+++ b/poetry.lock
@@ -340,13 +340,13 @@ files = [
 
 [[package]]
 name = "platformdirs"
-version = "4.0.0"
+version = "4.1.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "platformdirs-4.0.0-py3-none-any.whl", hash = "sha256:118c954d7e949b35437270383a3f2531e99dd93cf7ce4dc8340d3356d30f173b"},
-    {file = "platformdirs-4.0.0.tar.gz", hash = "sha256:cb633b2bcf10c51af60beb0ab06d2f1d69064b43abf4c185ca6b28865f3f9731"},
+    {file = "platformdirs-4.1.0-py3-none-any.whl", hash = "sha256:11c8f37bcca40db96d8144522d925583bdb7a31f7b0e37e3ed4318400a8e2380"},
+    {file = "platformdirs-4.1.0.tar.gz", hash = "sha256:906d548203468492d432bcb294d4bc2fff751bf84971fbb2c10918cc206ee420"},
 ]
 
 [package.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "microdata-tools"
-version = "0.11.6"
+version = "0.11.7"
 description = "Tools for the microdata.no platform"
 authors = ["microdata-developers"]
 license = "MIT License"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+def pytest_addoption(parser):
+    parser.addoption(
+        "--include-big-data",
+        action="store_true",
+        dest="include-big-data",
+        default=False,
+        help="enable big data testing",
+    )

--- a/tests/resources/validation/validate_dataset/big_datasets/ACCUMULATED_DS/ACCUMULATED_DS.json
+++ b/tests/resources/validation/validate_dataset/big_datasets/ACCUMULATED_DS/ACCUMULATED_DS.json
@@ -1,0 +1,78 @@
+{
+  "temporalityType": "ACCUMULATED",
+  "sensitivityLevel": "PERSON_GENERAL",
+  "populationDescription": [
+    {
+      "languageCode": "no",
+      "value": "Bosatte i Norge"
+    }
+  ],
+  "spatialCoverageDescription": [
+    {
+      "languageCode": "no",
+      "value": "Norge"
+    }
+  ],
+  "subjectFields": [
+    [
+      {
+        "languageCode": "no",
+        "value": "Økonomi"
+      }
+    ],
+    [
+      {
+        "languageCode": "no",
+        "value": "Samfunn"
+      }
+    ]
+  ],
+  "dataRevision": {
+    "description": [
+      {
+        "languageCode": "no",
+        "value": "Første publisering."
+      }
+    ],
+    "temporalEndOfSeries": false
+  },
+  "identifierVariables": [
+    {
+      "unitType": "PERSON"
+    }
+  ],
+  "measureVariables": [
+    {
+      "name": [
+        {
+          "languageCode": "no",
+          "value": "Personens inntekt"
+        }
+      ],
+      "description": [
+        {
+          "languageCode": "no",
+          "value": "Personens rapporterte inntekt"
+        }
+      ],
+      "dataType": "LONG",
+      "uriDefinition": [],
+      "valueDomain": {
+        "uriDefinition": [],
+        "description": [
+          {
+            "languageCode": "no",
+            "value": "Årlig personinntekt"
+          }
+        ],
+        "measurementType": "CURRENCY",
+        "measurementUnitDescription": [
+          {
+            "languageCode": "no",
+            "value": "Norske Kroner"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/resources/validation/validate_dataset/big_datasets/EVENT_DS/EVENT_DS.json
+++ b/tests/resources/validation/validate_dataset/big_datasets/EVENT_DS/EVENT_DS.json
@@ -1,0 +1,78 @@
+{
+  "temporalityType": "EVENT",
+  "sensitivityLevel": "PERSON_GENERAL",
+  "populationDescription": [
+    {
+      "languageCode": "no",
+      "value": "Bosatte i Norge"
+    }
+  ],
+  "spatialCoverageDescription": [
+    {
+      "languageCode": "no",
+      "value": "Norge"
+    }
+  ],
+  "subjectFields": [
+    [
+      {
+        "languageCode": "no",
+        "value": "Økonomi"
+      }
+    ],
+    [
+      {
+        "languageCode": "no",
+        "value": "Samfunn"
+      }
+    ]
+  ],
+  "dataRevision": {
+    "description": [
+      {
+        "languageCode": "no",
+        "value": "Første publisering."
+      }
+    ],
+    "temporalEndOfSeries": false
+  },
+  "identifierVariables": [
+    {
+      "unitType": "PERSON"
+    }
+  ],
+  "measureVariables": [
+    {
+      "name": [
+        {
+          "languageCode": "no",
+          "value": "Personens inntekt"
+        }
+      ],
+      "description": [
+        {
+          "languageCode": "no",
+          "value": "Personens rapporterte inntekt"
+        }
+      ],
+      "dataType": "LONG",
+      "uriDefinition": [],
+      "valueDomain": {
+        "uriDefinition": [],
+        "description": [
+          {
+            "languageCode": "no",
+            "value": "Årlig personinntekt"
+          }
+        ],
+        "measurementType": "CURRENCY",
+        "measurementUnitDescription": [
+          {
+            "languageCode": "no",
+            "value": "Norske Kroner"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/resources/validation/validate_dataset/big_datasets/FIXED_DS/FIXED_DS.json
+++ b/tests/resources/validation/validate_dataset/big_datasets/FIXED_DS/FIXED_DS.json
@@ -1,0 +1,78 @@
+{
+  "temporalityType": "FIXED",
+  "sensitivityLevel": "PERSON_GENERAL",
+  "populationDescription": [
+    {
+      "languageCode": "no",
+      "value": "Bosatte i Norge"
+    }
+  ],
+  "spatialCoverageDescription": [
+    {
+      "languageCode": "no",
+      "value": "Norge"
+    }
+  ],
+  "subjectFields": [
+    [
+      {
+        "languageCode": "no",
+        "value": "Økonomi"
+      }
+    ],
+    [
+      {
+        "languageCode": "no",
+        "value": "Samfunn"
+      }
+    ]
+  ],
+  "dataRevision": {
+    "description": [
+      {
+        "languageCode": "no",
+        "value": "Første publisering."
+      }
+    ],
+    "temporalEndOfSeries": false
+  },
+  "identifierVariables": [
+    {
+      "unitType": "PERSON"
+    }
+  ],
+  "measureVariables": [
+    {
+      "name": [
+        {
+          "languageCode": "no",
+          "value": "Personens inntekt"
+        }
+      ],
+      "description": [
+        {
+          "languageCode": "no",
+          "value": "Personens rapporterte inntekt"
+        }
+      ],
+      "dataType": "LONG",
+      "uriDefinition": [],
+      "valueDomain": {
+        "uriDefinition": [],
+        "description": [
+          {
+            "languageCode": "no",
+            "value": "Årlig personinntekt"
+          }
+        ],
+        "measurementType": "CURRENCY",
+        "measurementUnitDescription": [
+          {
+            "languageCode": "no",
+            "value": "Norske Kroner"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/resources/validation/validate_dataset/big_datasets/STATUS_DS/STATUS_DS.json
+++ b/tests/resources/validation/validate_dataset/big_datasets/STATUS_DS/STATUS_DS.json
@@ -1,0 +1,78 @@
+{
+  "temporalityType": "STATUS",
+  "sensitivityLevel": "PERSON_GENERAL",
+  "populationDescription": [
+    {
+      "languageCode": "no",
+      "value": "Bosatte i Norge"
+    }
+  ],
+  "spatialCoverageDescription": [
+    {
+      "languageCode": "no",
+      "value": "Norge"
+    }
+  ],
+  "subjectFields": [
+    [
+      {
+        "languageCode": "no",
+        "value": "Økonomi"
+      }
+    ],
+    [
+      {
+        "languageCode": "no",
+        "value": "Samfunn"
+      }
+    ]
+  ],
+  "dataRevision": {
+    "description": [
+      {
+        "languageCode": "no",
+        "value": "Første publisering."
+      }
+    ],
+    "temporalEndOfSeries": false
+  },
+  "identifierVariables": [
+    {
+      "unitType": "PERSON"
+    }
+  ],
+  "measureVariables": [
+    {
+      "name": [
+        {
+          "languageCode": "no",
+          "value": "Personens inntekt"
+        }
+      ],
+      "description": [
+        {
+          "languageCode": "no",
+          "value": "Personens rapporterte inntekt"
+        }
+      ],
+      "dataType": "LONG",
+      "uriDefinition": [],
+      "valueDomain": {
+        "uriDefinition": [],
+        "description": [
+          {
+            "languageCode": "no",
+            "value": "Årlig personinntekt"
+          }
+        ],
+        "measurementType": "CURRENCY",
+        "measurementUnitDescription": [
+          {
+            "languageCode": "no",
+            "value": "Norske Kroner"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/test_validation/test_validate_big_datasets.py
+++ b/tests/test_validation/test_validate_big_datasets.py
@@ -1,0 +1,76 @@
+import os
+
+import pytest
+
+from microdata_tools import validate_dataset
+
+
+RESOURCE_DIR = "tests/resources/validation/validate_dataset/big_datasets"
+
+VALID_DATASET_NAMES = [
+    "ACCUMULATED_DS",
+    "EVENT_DS",
+    "FIXED_DS",
+    "STATUS_DS",
+]
+
+
+def setup_function():
+    # The dates are intentionally shuffled to provoke errors
+    identifier_dates = {
+        "ACCUMULATED_DS": [
+            ("2020-01-01", "2020-12-31"),
+            ("2015-01-01", "2015-12-31"),
+            ("2012-01-01", "2012-12-31"),
+            ("2011-01-01", "2011-12-31"),
+            ("2013-01-01", "2013-12-31"),
+            ("2010-01-01", "2010-12-31"),
+            ("2007-01-01", "2007-12-31"),
+        ],
+        "EVENT_DS": [
+            ("2020-01-01", "2020-06-01"),
+            ("2015-01-01", "2015-06-01"),
+            ("2012-01-01", "2014-12-31"),
+            ("2011-01-01", "2011-12-31"),
+            ("2020-06-02", ""),
+            ("2015-06-02", "2019-12-31"),
+            ("2010-01-01", "2010-12-31"),
+        ],
+        "STATUS_DS": [
+            ("2020-01-01", "2020-01-01"),
+            ("2015-01-01", "2015-01-01"),
+            ("2012-01-01", "2012-01-01"),
+            ("2011-01-01", "2011-01-01"),
+            ("2013-01-01", "2013-01-01"),
+            ("2010-01-01", "2010-01-01"),
+            ("2007-01-01", "2007-01-01"),
+        ],
+        "FIXED_DS": [("", "2020-01-01")],
+    }
+    for dataset_name in VALID_DATASET_NAMES:
+        file_path = f"{RESOURCE_DIR}/{dataset_name}/{dataset_name}.csv"
+        with open(file_path, "w", encoding="utf-8") as f:
+            dates = identifier_dates[dataset_name]
+            identifier_amount = 2_000_000 if len(dates) == 7 else 14_000_000
+            for date in dates:
+                for i in range(identifier_amount):
+                    if i == 0:
+                        print(f"{i};{i};{date[0]};{date[1]};")
+                    f.write(f"{i};{i};{date[0]};{date[1]};\n")
+
+
+def teardown_function():
+    for dataset_name in VALID_DATASET_NAMES:
+        os.remove(f"{RESOURCE_DIR}/{dataset_name}/{dataset_name}.csv")
+
+
+@pytest.mark.skipif("not config.getoption('include-big-data')")
+def test_validate_big_dataset():
+    for dataset_name in VALID_DATASET_NAMES:
+        print(f"Validating {dataset_name}")
+        data_errors = validate_dataset(
+            dataset_name,
+            keep_temporary_files=False,
+            input_directory=RESOURCE_DIR,
+        )
+        assert not data_errors

--- a/tests/test_validation/test_validate_big_datasets.py
+++ b/tests/test_validation/test_validate_big_datasets.py
@@ -54,8 +54,6 @@ def setup_function():
             identifier_amount = 2_000_000 if len(dates) == 7 else 14_000_000
             for date in dates:
                 for i in range(identifier_amount):
-                    if i == 0:
-                        print(f"{i};{i};{date[0]};{date[1]};")
                     f.write(f"{i};{i};{date[0]};{date[1]};\n")
 
 


### PR DESCRIPTION
* New test module that generates 7 million row datasets of every temporality and runs the validator function on them
* The tests are skipped by default, but can be run as part of pytest with the "--include-big-data" argument
* Testing --include-big-data in the azure pipeline