### PR TITLE
Better metadata string validation

### DIFF
--- a/microdata_tools/validation/model/metadata.py
+++ b/microdata_tools/validation/model/metadata.py
@@ -78,9 +78,9 @@ class IdentifierVariable(BaseModel, extra=Extra.forbid):
 
 
 class CodeListItem(BaseModel, extra=Extra.forbid):
-    code: str
+    code: str = Field(min_length=1)
     categoryTitle: conlist(MultiLingualString, min_items=1)
-    validFrom: str
+    validFrom: str = Field(min_length=1)
     validUntil: Optional[Union[str, None]]
 
     @root_validator(skip_on_failure=True)
@@ -106,7 +106,7 @@ class CodeListItem(BaseModel, extra=Extra.forbid):
 
 
 class SentinelItem(BaseModel, extra=Extra.forbid):
-    code: str
+    code: str = Field(min_length=1)
     categoryTitle: conlist(MultiLingualString, min_items=1)
 
 

--- a/microdata_tools/validation/model/metadata.py
+++ b/microdata_tools/validation/model/metadata.py
@@ -2,7 +2,7 @@ import datetime
 from enum import Enum
 from typing import Optional, List, Union
 
-from pydantic import BaseModel, conlist, root_validator, Extra
+from pydantic import BaseModel, Field, conlist, root_validator, Extra
 
 
 class TemporalityType(str, Enum):
@@ -65,7 +65,7 @@ class UnitIdType(str, Enum):
 
 class MultiLingualString(BaseModel):
     languageCode: LanguageCode
-    value: str
+    value: str = Field(min_length=1)
 
 
 class DataRevision(BaseModel, extra=Extra.forbid):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "microdata-tools"
-version = "0.12.0"
+version = "0.13.0"
 description = "Tools for the microdata.no platform"
 authors = ["microdata-developers"]
 license = "MIT License"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "microdata-tools"
-version = "0.12.1"
+version = "0.12.0"
 description = "Tools for the microdata.no platform"
 authors = ["microdata-developers"]
 license = "MIT License"

--- a/tests/resources/validation/validate_metadata/input_directory/EMPTY_STRING_METADATA/EMPTY_STRING_METADATA.json
+++ b/tests/resources/validation/validate_metadata/input_directory/EMPTY_STRING_METADATA/EMPTY_STRING_METADATA.json
@@ -1,0 +1,78 @@
+{
+  "temporalityType": "ACCUMULATED",
+  "sensitivityLevel": "PERSON_GENERAL",
+  "populationDescription": [
+    {
+      "languageCode": "no",
+      "value": "Bosatte i Norge"
+    }
+  ],
+  "spatialCoverageDescription": [
+    {
+      "languageCode": "no",
+      "value": "Norge"
+    }
+  ],
+  "subjectFields": [
+    [
+      {
+        "languageCode": "no",
+        "value": "Økonomi"
+      }
+    ],
+    [
+      {
+        "languageCode": "no",
+        "value": "Samfunn"
+      }
+    ]
+  ],
+  "dataRevision": {
+    "description": [
+      {
+        "languageCode": "no",
+        "value": "Første publisering."
+      }
+    ],
+    "temporalEndOfSeries": false
+  },
+  "identifierVariables": [
+    {
+      "unitType": "PERSON"
+    }
+  ],
+  "measureVariables": [
+    {
+      "name": [
+        {
+          "languageCode": "no",
+          "value": ""
+        }
+      ],
+      "description": [
+        {
+          "languageCode": "no",
+          "value": "Personens rapporterte inntekt"
+        }
+      ],
+      "dataType": "LONG",
+      "uriDefinition": [],
+      "valueDomain": {
+        "uriDefinition": [],
+        "description": [
+          {
+            "languageCode": "no",
+            "value": "Årlig personinntekt"
+          }
+        ],
+        "measurementType": "CURRENCY",
+        "measurementUnitDescription": [
+          {
+            "languageCode": "no",
+            "value": "Norske Kroner"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/test_validation/test_validate_metadata.py
+++ b/tests/test_validation/test_validate_metadata.py
@@ -21,6 +21,7 @@ VALID_METADATA = ["SYNT_BEFOLKNING_SIVSTAND", "SYNT_PERSON_INNTEKT"]
 
 NO_SUCH_METADATA = "NO_SUCH_METADATA"
 MISSING_IDENTIFIER_METADATA = "MISSING_IDENTIFIER_DATASET"
+EMPTY_STRING_METADATA = "EMPTY_STRING_METADATA"
 
 
 def test_validate_valid_metadata():
@@ -68,6 +69,15 @@ def test_validate_metadata_does_not_exist():
     data_errors = validate_metadata(NO_SUCH_METADATA, INPUT_DIR)
     assert len(data_errors) == 1
     assert "not found" in data_errors[0]
+
+
+def test_validate_metadata_empty_string():
+    data_errors = validate_metadata(EMPTY_STRING_METADATA, INPUT_DIR)
+    assert len(data_errors) == 1
+    assert (
+        "measureVariables->name->value: ensure this value has at least 1 characters"
+        in data_errors[0]
+    )
 
 
 def get_working_directory_files() -> list:


### PR DESCRIPTION
Tested with all the INNTEKT variables from s380 without any unexpected errors. (One dataset had one error unrelated to this change)