### PR TITLE
github_actions: remove bugged step

### DIFF
--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -31,3 +31,26 @@ jobs:
 
     - name: Run tests
       run: poetry run pytest --cov=microdata_tools
+
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    environment: PyPI 
+    needs: test
+    if: success()
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.11
+
+    - name: Install dependencies
+      run: |
+        curl -sSL https://install.python-poetry.org | python -
+        poetry install
+
+    - name: Build and publish
+      run: poetry publish --build

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -53,4 +53,4 @@ jobs:
         poetry install
 
     - name: Build and publish
-      run: poetry publish --build
+      run: poetry publish --build --username ${{ secrets.PYPI_USER }} --password ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -32,25 +32,3 @@ jobs:
     - name: Run tests
       run: poetry run pytest --cov=microdata_tools
 
-  publish:
-    name: Publish
-    runs-on: ubuntu-latest
-    environment: PyPI 
-    needs: test
-    if: success()
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.11
-
-    - name: Install dependencies
-      run: |
-        curl -sSL https://install.python-poetry.org | python -
-        poetry install
-
-    - name: Build and publish
-      run: poetry publish --build --username ${{ secrets.PYPI_USER }} --password ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -32,9 +32,6 @@ jobs:
       id: test
       run: poetry run pytest
 
-    - name: Check test results
-      run: exit ${{ steps.test.outcome }}
-
   publish:
     name: Publish
     runs-on: ubuntu-latest

--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -41,16 +41,16 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
-    
+
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
         python-version: 3.11
-    
+
     - name: Install dependencies
       run: |
         curl -sSL https://install.python-poetry.org | python -
         poetry install
 
     - name: Build and publish
-      run: poetry publish --build
+      run: poetry publish --build --username ${{ secrets.PYPI_USER }} --password ${{ secrets.PYPI_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "microdata-tools"
-version = "0.13.0"
+version = "0.13.1"
 description = "Tools for the microdata.no platform"
 authors = ["microdata-developers"]
 license = "MIT License"
@@ -13,13 +13,11 @@ cryptography = ">=41.0.1,<43.0.0"
 pydantic = "^1.10.9"
 pyarrow = "^14.0.1"
 
-
 [tool.poetry.group.dev.dependencies]
 black = "^23.3.0"
 ruff = "^0.0.272"
 pytest = "^7.3.2"
 pytest-cov = "^4.1.0"
-cryptography = ">=41.0.1,<43.0.0"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Moved to auth with token like before as the trusted publisher was not as well documented and supported. We can switch to a trusted publisher later. Still using the protected github environment