### PR TITLE
Extend model for temporal end of series

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ These fields describe the dataset as a whole.
 ### DATAREVISION
 These fields describe the current version of the dataset.
 * **description**: Description of this version of the dataset.
-* **temporalEndOfSeries**: Is this the final update for this dataset? [True | False]
+* **temporalEnd (Optional)**: Description of why this dataset will not be updated anymore. Successor datasets can be optionally specified. 
 
 ### IDENTIFIER VARIABLES
 Description of the indentifier column of the dataset. It is represented as a list in the metadata model, but currently only one identifier is allowed per dataset. The identifiers are always based on a unit. A unit is centrally defined to make joining datasets across datastores easy.

--- a/docs/examples/BEFOLKNING_BOSTED/BEFOLKNING_BOSTED.json
+++ b/docs/examples/BEFOLKNING_BOSTED/BEFOLKNING_BOSTED.json
@@ -7,8 +7,7 @@
 		[{"languageCode": "no", "value": "BEFOLKNING"}]
 	],
 	"dataRevision": {
-		"description": [{"languageCode": "no","value": "Første publisering."}],
-		"temporalEndOfSeries": false
+		"description": [{"languageCode": "no","value": "Første publisering."}]
 	},
 	"identifierVariables": [{"unitType": "PERSON"}],
 	"measureVariables": [

--- a/docs/examples/BEFOLKNING_INNTEKT/BEFOLKNING_INNTEKT.json
+++ b/docs/examples/BEFOLKNING_INNTEKT/BEFOLKNING_INNTEKT.json
@@ -8,8 +8,7 @@
 		[{"languageCode": "no", "value": "SAMFUNN"}]
 	],
 	"dataRevision": {
-		"description": [{"languageCode": "no","value": "Første publisering."}],
-		"temporalEndOfSeries": false
+		"description": [{"languageCode": "no","value": "Første publisering."}]
 	},
 	"identifierVariables": [{"unitType": "PERSON"}],
 	"measureVariables": [

--- a/docs/examples/BEFOLKNING_KJOENN/BEFOLKNING_KJOENN.json
+++ b/docs/examples/BEFOLKNING_KJOENN/BEFOLKNING_KJOENN.json
@@ -8,8 +8,7 @@
     [{"languageCode": "no", "value": "SAMFUNN"}]
   ],
   "dataRevision": {
-    "description": [{"languageCode": "no","value": "Første publisering."}],
-    "temporalEndOfSeries": false
+    "description": [{"languageCode": "no","value": "Første publisering."}]
   },
   "identifierVariables": [{"unitType": "PERSON"}],
   "measureVariables": [

--- a/docs/examples/BEFOLKNING_SIVILSTAND/BEFOLKNING_SIVILSTAND.json
+++ b/docs/examples/BEFOLKNING_SIVILSTAND/BEFOLKNING_SIVILSTAND.json
@@ -9,7 +9,9 @@
 	],
 	"dataRevision": {
 		"description": [{"languageCode": "no","value": "Første publisering."}],
-		"temporalEndOfSeries": false
+		"temporalEnd": {
+			"description": [{"languageCode": "no","value": "Variabelen blir ikke lenger oppdatert"}]
+		}
 	},
 	"identifierVariables": [{"unitType": "PERSON"}],
 	"measureVariables": [

--- a/microdata_tools/validation/model/metadata.py
+++ b/microdata_tools/validation/model/metadata.py
@@ -76,7 +76,7 @@ class MultiLingualString(BaseModel):
 
 class TemporalEnd(BaseModel):
     description: conlist(MultiLingualString, min_length=1)
-    successors: Optional[list[str]] = None
+    successors: Optional[List[str]] = None
 
 
 class DataRevision(BaseModel, extra="forbid"):

--- a/microdata_tools/validation/model/metadata.py
+++ b/microdata_tools/validation/model/metadata.py
@@ -76,7 +76,7 @@ class MultiLingualString(BaseModel):
 
 class TemporalEnd(BaseModel):
     description: conlist(MultiLingualString, min_length=1)
-    successors: Optional[List[str]] = None
+    successors: Optional[conlist(str, min_length=1)] = None
 
 
 class DataRevision(BaseModel, extra="forbid"):

--- a/microdata_tools/validation/model/metadata.py
+++ b/microdata_tools/validation/model/metadata.py
@@ -74,9 +74,14 @@ class MultiLingualString(BaseModel):
     value: str = Field(min_length=1)
 
 
+class TemporalEnd(BaseModel):
+    description: conlist(MultiLingualString, min_length=1)
+    successors: Optional[list[str]] = None
+
+
 class DataRevision(BaseModel, extra="forbid"):
     description: conlist(MultiLingualString, min_length=1)
-    temporalEndOfSeries: bool
+    temporalEnd: Optional[TemporalEnd] = None
 
 
 class IdentifierVariable(BaseModel, extra="forbid"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "microdata-tools"
-version = "0.18.0"
+version = "1.0.0"
 description = "Tools for the microdata.no platform"
 authors = ["microdata-developers"]
 license = "MIT License"

--- a/tests/resources/validation/components/unit_type_variables/metadata_template.json
+++ b/tests/resources/validation/components/unit_type_variables/metadata_template.json
@@ -8,8 +8,7 @@
     [{"languageCode": "no", "value": "SAMFUNN"}]
   ],
   "dataRevision": {
-    "description": [{"languageCode": "no","value": "Første publisering."}],
-    "temporalEndOfSeries": false
+    "description": [{"languageCode": "no","value": "Første publisering."}]
   },
   "identifierVariables": [{"unitType": "PERSON"}],
   "measureVariables": [

--- a/tests/resources/validation/steps/metadata_enricher/VALID_EVENT_METADATA.json
+++ b/tests/resources/validation/steps/metadata_enricher/VALID_EVENT_METADATA.json
@@ -5,8 +5,7 @@
   "spatialCoverageDescription": [{ "languageCode": "no", "value": "Norge" }],
   "subjectFields": [[{ "languageCode": "no", "value": "Samfunn" }]],
   "dataRevision": {
-    "description": [{ "languageCode": "no", "value": "Første publisering." }],
-    "temporalEndOfSeries": false
+    "description": [{ "languageCode": "no", "value": "Første publisering." }]
   },
   "identifierVariables": [
     { "unitType": "PERSON" }

--- a/tests/resources/validation/steps/metadata_enricher/VALID_STATUS_METADATA.json
+++ b/tests/resources/validation/steps/metadata_enricher/VALID_STATUS_METADATA.json
@@ -5,8 +5,7 @@
     "spatialCoverageDescription": [{ "languageCode": "no", "value": "Norge" }],
     "subjectFields": [[{ "languageCode": "no", "value": "Samfunn" }]],
     "dataRevision": {
-      "description": [{ "languageCode": "no", "value": "Første publisering." }],
-      "temporalEndOfSeries": false
+      "description": [{ "languageCode": "no", "value": "Første publisering." }]
     },
     "identifierVariables": [
       { "unitType": "PERSON" }

--- a/tests/resources/validation/steps/metadata_reader/EMPTY_CODELIST.json
+++ b/tests/resources/validation/steps/metadata_reader/EMPTY_CODELIST.json
@@ -7,8 +7,7 @@
     ],
     "spatialCoverageDescription": [{"languageCode": "no", "value": "Norge"}],
     "dataRevision": {
-      "description": [{"languageCode": "no","value": "Første publisering."}],
-      "temporalEndOfSeries": false
+      "description": [{"languageCode": "no","value": "Første publisering."}]
     },
     "identifierVariables": [{"unitType": "PERSON"}],
     "measureVariables": [

--- a/tests/resources/validation/steps/metadata_reader/EXTRA_FIELDS.json
+++ b/tests/resources/validation/steps/metadata_reader/EXTRA_FIELDS.json
@@ -9,7 +9,6 @@
     ],
     "dataRevision": {
       "description": [{"languageCode": "no","value": "Første publisering."}],
-      "temporalEndOfSeries": false,
       "newTypeOfField": "INVALID"
     },
     "identifierVariables": [{"unitType": "PERSON", "invalidField": "here"}],

--- a/tests/resources/validation/steps/metadata_reader/EXTRA_FIELDS_UNIT_MEASURE.json
+++ b/tests/resources/validation/steps/metadata_reader/EXTRA_FIELDS_UNIT_MEASURE.json
@@ -4,8 +4,7 @@
     "populationDescription": [{"languageCode": "no", "value": "Kjønn for en populasjon"}],
     "spatialCoverageDescription": [{"languageCode": "no", "value": "Norge"}],
     "dataRevision": {
-      "description": [{"languageCode": "no","value": "Første publisering."}],
-      "temporalEndOfSeries": false
+      "description": [{"languageCode": "no","value": "Første publisering."}]
     },
     "subjectFields": [
       [{"languageCode": "no", "value": "Helsetjenester"}]

--- a/tests/resources/validation/steps/metadata_reader/INVALID_SENSITIVITY.json
+++ b/tests/resources/validation/steps/metadata_reader/INVALID_SENSITIVITY.json
@@ -4,8 +4,7 @@
     "populationDescription": [{"languageCode": "no", "value": "Kjønn for en populasjon"}],
     "spatialCoverageDescription": [{"languageCode": "no", "value": "Norge"}],
     "dataRevision": {
-      "description": [{"languageCode": "no","value": "Første publisering."}],
-      "temporalEndOfSeries": false
+      "description": [{"languageCode": "no","value": "Første publisering."}]
     },
     "subjectFields": [
       [{"languageCode": "no", "value": "Helsetjenester"}]

--- a/tests/resources/validation/steps/metadata_reader/INVALID_UNIT_TYPE.json
+++ b/tests/resources/validation/steps/metadata_reader/INVALID_UNIT_TYPE.json
@@ -33,8 +33,7 @@
           "languageCode": "no",
           "value": "Første publisering."
         }
-      ],
-      "temporalEndOfSeries": false
+      ]
     },
     "identifierVariables": [
       {

--- a/tests/resources/validation/steps/metadata_reader/MISSING_IDENTIFIER.json
+++ b/tests/resources/validation/steps/metadata_reader/MISSING_IDENTIFIER.json
@@ -7,8 +7,7 @@
       [{"languageCode": "no", "value": "Befolkning"}]
     ],
     "dataRevision": {
-      "description": [{"languageCode": "no","value": "Første publisering."}],
-      "temporalEndOfSeries": false
+      "description": [{"languageCode": "no","value": "Første publisering."}]
     },
     "measureVariables": [
       {

--- a/tests/resources/validation/steps/metadata_reader/UNIT_MEASURE.json
+++ b/tests/resources/validation/steps/metadata_reader/UNIT_MEASURE.json
@@ -4,8 +4,7 @@
     "populationDescription": [{"languageCode": "no", "value": "Kjønn for en populasjon"}],
     "spatialCoverageDescription": [{"languageCode": "no", "value": "Norge"}],
     "dataRevision": {
-      "description": [{"languageCode": "no","value": "Første publisering."}],
-      "temporalEndOfSeries": false
+      "description": [{"languageCode": "no","value": "Første publisering."}]
     },
     "subjectFields": [
       [{"languageCode": "no", "value": "Helsetjenester"}]

--- a/tests/resources/validation/steps/metadata_reader/VALID.json
+++ b/tests/resources/validation/steps/metadata_reader/VALID.json
@@ -33,8 +33,7 @@
           "languageCode": "no",
           "value": "Første publisering."
         }
-      ],
-      "temporalEndOfSeries": false
+      ]
     },
     "identifierVariables": [
       {

--- a/tests/resources/validation/validate_dataset/big_datasets/ACCUMULATED_DS/ACCUMULATED_DS.json
+++ b/tests/resources/validation/validate_dataset/big_datasets/ACCUMULATED_DS/ACCUMULATED_DS.json
@@ -33,8 +33,7 @@
         "languageCode": "no",
         "value": "Første publisering."
       }
-    ],
-    "temporalEndOfSeries": false
+    ]
   },
   "identifierVariables": [
     {

--- a/tests/resources/validation/validate_dataset/big_datasets/EVENT_DS/EVENT_DS.json
+++ b/tests/resources/validation/validate_dataset/big_datasets/EVENT_DS/EVENT_DS.json
@@ -33,8 +33,7 @@
         "languageCode": "no",
         "value": "Første publisering."
       }
-    ],
-    "temporalEndOfSeries": false
+    ]
   },
   "identifierVariables": [
     {

--- a/tests/resources/validation/validate_dataset/big_datasets/FIXED_DS/FIXED_DS.json
+++ b/tests/resources/validation/validate_dataset/big_datasets/FIXED_DS/FIXED_DS.json
@@ -33,8 +33,7 @@
         "languageCode": "no",
         "value": "Første publisering."
       }
-    ],
-    "temporalEndOfSeries": false
+    ]
   },
   "identifierVariables": [
     {

--- a/tests/resources/validation/validate_dataset/big_datasets/STATUS_DS/STATUS_DS.json
+++ b/tests/resources/validation/validate_dataset/big_datasets/STATUS_DS/STATUS_DS.json
@@ -33,8 +33,7 @@
         "languageCode": "no",
         "value": "Første publisering."
       }
-    ],
-    "temporalEndOfSeries": false
+    ]
   },
   "identifierVariables": [
     {

--- a/tests/resources/validation/validate_dataset/expected/SYNT_BEFOLKNING_SIVSTAND.json
+++ b/tests/resources/validation/validate_dataset/expected/SYNT_BEFOLKNING_SIVSTAND.json
@@ -29,7 +29,6 @@
         "value": "Første publisering."
       }
     ],
-    "temporalEndOfSeries": false,
     "temporalCoverageStart": "1920-01-01",
     "temporalCoverageLatest": "1951-01-02"
   },

--- a/tests/resources/validation/validate_dataset/expected/SYNT_PERSON_INNTEKT.json
+++ b/tests/resources/validation/validate_dataset/expected/SYNT_PERSON_INNTEKT.json
@@ -35,7 +35,6 @@
         "value": "Første publisering."
       }
     ],
-    "temporalEndOfSeries": false,
     "temporalCoverageStart": "1970-01-01",
     "temporalCoverageLatest": "2020-12-31"
   },

--- a/tests/resources/validation/validate_dataset/expected/SYNT_PERSON_MOR.json
+++ b/tests/resources/validation/validate_dataset/expected/SYNT_PERSON_MOR.json
@@ -29,7 +29,6 @@
         "value": "Første publisering."
       }
     ],
-    "temporalEndOfSeries": false,
     "temporalCoverageStart": "1900-01-01",
     "temporalCoverageLatest": "2020-01-01"
   },

--- a/tests/resources/validation/validate_dataset/expected/SYNT_UTDANNING.json
+++ b/tests/resources/validation/validate_dataset/expected/SYNT_UTDANNING.json
@@ -20,7 +20,6 @@
         "value": "F\u00f8rste publisering."
       }
     ],
-    "temporalEndOfSeries": false,
     "temporalCoverageStart": "1990-01-01",
     "temporalCoverageLatest": "1994-01-01",
     "temporalStatusDates": [

--- a/tests/resources/validation/validate_dataset/input_directory/SYNT_BEFOLKNING_SIVSTAND/SYNT_BEFOLKNING_SIVSTAND.json
+++ b/tests/resources/validation/validate_dataset/input_directory/SYNT_BEFOLKNING_SIVSTAND/SYNT_BEFOLKNING_SIVSTAND.json
@@ -7,8 +7,7 @@
     [{"languageCode": "no", "value": "Befolkning"}]
   ],
   "dataRevision": {
-    "description": [{"languageCode": "no","value": "Første publisering."}],
-    "temporalEndOfSeries": false
+    "description": [{"languageCode": "no","value": "Første publisering."}]
   },
   "identifierVariables": [{"unitType": "PERSON"}],
   "measureVariables": [

--- a/tests/resources/validation/validate_dataset/input_directory/SYNT_PERSON_INNTEKT/SYNT_PERSON_INNTEKT.json
+++ b/tests/resources/validation/validate_dataset/input_directory/SYNT_PERSON_INNTEKT/SYNT_PERSON_INNTEKT.json
@@ -33,8 +33,7 @@
         "languageCode": "no",
         "value": "Første publisering."
       }
-    ],
-    "temporalEndOfSeries": false
+    ]
   },
   "identifierVariables": [
     {

--- a/tests/resources/validation/validate_dataset/input_directory/SYNT_PERSON_MOR/SYNT_PERSON_MOR.json
+++ b/tests/resources/validation/validate_dataset/input_directory/SYNT_PERSON_MOR/SYNT_PERSON_MOR.json
@@ -7,8 +7,7 @@
       [{"languageCode": "no", "value": "Befolkning"}]
     ],
     "dataRevision": {
-      "description": [{"languageCode": "no","value": "Første publisering."}],
-      "temporalEndOfSeries": false
+      "description": [{"languageCode": "no","value": "Første publisering."}]
     },
     "identifierVariables": [{"unitType": "PERSON"}],
     "measureVariables": [

--- a/tests/resources/validation/validate_dataset/input_directory/SYNT_UTDANNING/SYNT_UTDANNING.json
+++ b/tests/resources/validation/validate_dataset/input_directory/SYNT_UTDANNING/SYNT_UTDANNING.json
@@ -7,8 +7,7 @@
       [{"languageCode": "no", "value": "Befolkning"}]
     ],
     "dataRevision": {
-      "description": [{"languageCode": "no","value": "Første publisering."}],
-      "temporalEndOfSeries": false
+      "description": [{"languageCode": "no","value": "Første publisering."}]
     },
     "identifierVariables": [{"unitType": "PERSON"}],
     "measureVariables": [

--- a/tests/resources/validation/validate_metadata/expected/SYNT_BEFOLKNING_SIVSTAND.json
+++ b/tests/resources/validation/validate_metadata/expected/SYNT_BEFOLKNING_SIVSTAND.json
@@ -28,7 +28,14 @@
         "value": "F\u00f8rste publisering."
       }
     ],
-    "temporalEndOfSeries": false
+    "temporalEnd": {
+      "description": [
+        {
+          "languageCode": "no",
+          "value": "Variabelen blir ikke lenger oppdatert"
+        }
+      ]
+    }
   },
   "identifierVariables": [
     {

--- a/tests/resources/validation/validate_metadata/expected/SYNT_PERSON_INNTEKT.json
+++ b/tests/resources/validation/validate_metadata/expected/SYNT_PERSON_INNTEKT.json
@@ -34,7 +34,18 @@
         "value": "F\u00f8rste publisering."
       }
     ],
-    "temporalEndOfSeries": false
+    "temporalEnd": {
+      "description": [
+        {
+          "languageCode": "no",
+          "value": "Variabelen blir ikke lenger oppdatert"
+        }
+      ],
+      "successors": [
+        "SYNT_PERSON_INNTEKT_FOR_SKATT",
+        "SYNT_PERSON_INNTEKT_ETTER_SKATT"
+      ]
+    }
   },
   "identifierVariables": [
     {

--- a/tests/resources/validation/validate_metadata/input_directory/EMPTY_STRING_METADATA/EMPTY_STRING_METADATA.json
+++ b/tests/resources/validation/validate_metadata/input_directory/EMPTY_STRING_METADATA/EMPTY_STRING_METADATA.json
@@ -33,8 +33,7 @@
         "languageCode": "no",
         "value": "Første publisering."
       }
-    ],
-    "temporalEndOfSeries": false
+    ]
   },
   "identifierVariables": [
     {

--- a/tests/resources/validation/validate_metadata/input_directory/MISSING_IDENTIFIER_DATASET/MISSING_IDENTIFIER_DATASET.json
+++ b/tests/resources/validation/validate_metadata/input_directory/MISSING_IDENTIFIER_DATASET/MISSING_IDENTIFIER_DATASET.json
@@ -7,8 +7,7 @@
       [{"languageCode": "no", "value": "Befolkning"}]
     ],
     "dataRevision": {
-      "description": [{"languageCode": "no","value": "Første publisering."}],
-      "temporalEndOfSeries": false
+      "description": [{"languageCode": "no","value": "Første publisering."}]
     },
     "measureVariables": [
       {

--- a/tests/resources/validation/validate_metadata/input_directory/SYNT_BEFOLKNING_SIVSTAND/SYNT_BEFOLKNING_SIVSTAND.json
+++ b/tests/resources/validation/validate_metadata/input_directory/SYNT_BEFOLKNING_SIVSTAND/SYNT_BEFOLKNING_SIVSTAND.json
@@ -8,7 +8,9 @@
   ],
   "dataRevision": {
     "description": [{"languageCode": "no","value": "Første publisering."}],
-    "temporalEndOfSeries": false
+    "temporalEnd": {
+      "description": [{"languageCode": "no","value": "Variabelen blir ikke lenger oppdatert"}]
+    }
   },
   "identifierVariables": [{"unitType": "PERSON"}],
   "measureVariables": [

--- a/tests/resources/validation/validate_metadata/input_directory/SYNT_PERSON_INNTEKT/SYNT_PERSON_INNTEKT.json
+++ b/tests/resources/validation/validate_metadata/input_directory/SYNT_PERSON_INNTEKT/SYNT_PERSON_INNTEKT.json
@@ -34,7 +34,18 @@
         "value": "Første publisering."
       }
     ],
-    "temporalEndOfSeries": false
+    "temporalEnd": {
+      "description": [
+        {
+          "languageCode": "no",
+          "value": "Variabelen blir ikke lenger oppdatert"
+        }
+      ],
+      "successors": [
+        "SYNT_PERSON_INNTEKT_FOR_SKATT",
+        "SYNT_PERSON_INNTEKT_ETTER_SKATT"
+      ]
+    }
   },
   "identifierVariables": [
     {

--- a/tests/test_validation/test_validate_metadata.py
+++ b/tests/test_validation/test_validate_metadata.py
@@ -1,13 +1,9 @@
-import os
 import json
 import logging
+import os
 from pathlib import Path
 
-import pytest
-
 from microdata_tools import validate_metadata
-from microdata_tools.validation.exceptions import ValidationError
-
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)


### PR DESCRIPTION
It is possible now to describe why a dataset will not be updated anymore. Successor datasets can be optionally specified.
I will wait with merging this PR until job-executor is also updated.