### PR TITLE
Specify required uv version

### DIFF
--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -91,7 +91,7 @@ jobs:
       - name: Detect and tag new version
         id: check-version
         if: steps.check-parent-commit.outputs.sha
-        uses: salsify/action-detect-and-tag-new-version@v2.0.3
+        uses: salsify/action-detect-and-tag-new-version@b1778166f13188a9d478e2d1198f993011ba9864 #v2.0.3
         with:
           version-command: |
             bash -o pipefail -c "uv version --short"
@@ -101,7 +101,7 @@ jobs:
           uv build
 
       - name: Publish the release notes
-        uses: release-drafter/release-drafter@v6.0.0
+        uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 #v6.1.0
         with:
           publish: ${{ steps.check-version.outputs.tag != '' }}
           tag: ${{ steps.check-version.outputs.tag }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dev = [
 
 [tool.uv]
 package = true
+required-version = ">=0.7.0"
 
 [tool.ruff]
 line-length = 80


### PR DESCRIPTION
Some version control:
- Specify min. required uv version (to ensure the `uv version --short` command works)
- Best practice: Use sha-tags insted of versions for actions release-drafter and salsify/action-detect-and-tag-new-version