### PR TITLE
Stream CSV files directly to Parquet files instead of reading everything into memory #105

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ __pycache__/
 # C extensions
 *.so
 
+tmp/
+
 # Distribution / packaging
 .Python
 build/
@@ -57,6 +59,18 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 cover/
+
+tests/resources/validation/validate_dataset/big_datasets/ACCUMULATED_DS/ACCUMULATED_DS.csv
+tests/resources/validation/validate_dataset/big_datasets/ACCUMULATED_DS/ACCUMULATED_DS.csv.rowcount
+
+tests/resources/validation/validate_dataset/big_datasets/EVENT_DS/EVENT_DS.csv
+tests/resources/validation/validate_dataset/big_datasets/EVENT_DS/EVENT_DS.csv.rowcount
+
+tests/resources/validation/validate_dataset/big_datasets/FIXED_DS/FIXED_DS.csv
+tests/resources/validation/validate_dataset/big_datasets/FIXED_DS/FIXED_DS.csv.rowcount
+
+tests/resources/validation/validate_dataset/big_datasets/STATUS_DS/STATUS_DS.csv
+tests/resources/validation/validate_dataset/big_datasets/STATUS_DS/STATUS_DS.csv.rowcount
 
 # Translations
 *.mo

--- a/microdata_tools/validation/__init__.py
+++ b/microdata_tools/validation/__init__.py
@@ -2,7 +2,7 @@ import string
 from pathlib import Path
 from typing import List, Union
 
-from pyarrow import dataset, parquet
+import pyarrow
 
 from microdata_tools.validation.adapter import local_storage
 from microdata_tools.validation.components import unit_id_types
@@ -87,29 +87,31 @@ def validate_dataset(
         )
 
         # Read data
-        table = data_reader.read_and_sanitize_csv(
+        parquet_path = working_directory_path / f"{dataset_name}.parquet"
+        filesystem_dataset = data_reader.read_and_sanitize_csv_write_parquet(
             input_data_path,
+            parquet_path,
             identifier_data_type,
             measure_data_type,
             temporality_type,
         )
 
         # Enrich metadata with temporal data
-        temporal_data = data_reader.get_temporal_data(table, temporality_type)
+        temporal_data = data_reader.get_temporal_data(
+            filesystem_dataset, temporality_type
+        )
         metadata_enricher.enrich_with_temporal_coverage(
             metadata_dict, temporal_data
         )
 
         # Write files to working directory
-        parquet_path = working_directory_path / f"{dataset_name}.parquet"
-        parquet.write_table(table, parquet_path)
         local_storage.write_json(
             working_directory_path / f"{dataset_name}.json", metadata_dict
         )
 
         # Validate data
         dataset_validator.validate_dataset(
-            dataset.dataset(parquet_path),
+            pyarrow.dataset.dataset(parquet_path),
             measure_data_type,
             code_list,
             sentinel_list,

--- a/microdata_tools/validation/steps/data_reader.py
+++ b/microdata_tools/validation/steps/data_reader.py
@@ -2,10 +2,12 @@
 import logging
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Tuple
 
 import pyarrow
-from pyarrow import ArrowInvalid, compute, csv
+import pyarrow.dataset
+import pyarrow.dataset as ds
+from pyarrow import ArrowInvalid, compute, csv, parquet
 
 from microdata_tools.validation.exceptions import ValidationError
 
@@ -23,6 +25,24 @@ def _microdata_data_type_to_pyarrow(
         return pyarrow.float64()
     elif microdata_data_type == "DATE":
         return pyarrow.date32()
+    else:
+        raise ValidationError(
+            "Unsupported measure data type",
+            errors=[f"Unsupported measure data type: {microdata_data_type}"],
+        )
+
+
+def _microdata_data_type_to_disk_pyarrow(
+    microdata_data_type: str,
+) -> pyarrow.lib.DataType:
+    if microdata_data_type == "STRING":
+        return pyarrow.string()
+    elif microdata_data_type == "LONG":
+        return pyarrow.int64()
+    elif microdata_data_type == "DOUBLE":
+        return pyarrow.float64()
+    elif microdata_data_type == "DATE":
+        return pyarrow.int64()
     else:
         raise ValidationError(
             "Unsupported measure data type",
@@ -54,22 +74,81 @@ def _get_csv_convert_options(
     )
 
 
-def _csv_to_table(
-    input_csv_path: Path, identifier_data_type: str, measure_data_type: str
-) -> pyarrow.Table:
+def _csv_stream_to_parquet(
+    identifier_data_type: str,
+    measure_data_type: str,
+    temporality_type: str,
+    reader: pyarrow.csv.CSVStreamingReader,
+    writer: pyarrow.parquet.ParquetWriter,
+) -> None:
+    while True:
+        try:
+            batch = reader.read_next_batch()
+        except StopIteration:
+            break
+        table = pyarrow.Table.from_batches([batch])
+        unit_id = _sanitize_unit_id(table, identifier_data_type)
+        value = _sanitize_value(table, measure_data_type)
+        epoch_start = _cast_to_epoch_date(table, "start")
+        epoch_stop = _cast_to_epoch_date(table, "stop")
+        columns = [unit_id, value, epoch_start, epoch_stop]
+        column_names = [
+            "unit_id",
+            "value",
+            "start_epoch_days",
+            "stop_epoch_days",
+        ]
+        if temporality_type in ["STATUS", "ACCUMULATED"]:
+            columns.append(_generate_start_year(table))
+            column_names.append("start_year")
+        table = pyarrow.Table.from_arrays(columns, column_names)
+        writer.write_table(table)
+
+
+def _csv_to_parquet(
+    input_csv_path: Path,
+    output_parquet_path: str,
+    identifier_data_type: str,
+    measure_data_type: str,
+    temporality_type: str,
+) -> pyarrow.dataset.FileSystemDataset:
     """
     Read a csv into a pyarrow table. The read and convert options
     ensures microdata formatting of the input csv.
     """
     try:
-        return csv.read_csv(
+        with csv.open_csv(
             input_csv_path,
             parse_options=csv.ParseOptions(delimiter=";"),
             read_options=_get_csv_read_options(),
             convert_options=_get_csv_convert_options(
                 identifier_data_type, measure_data_type
             ),
-        )
+        ) as reader:
+            schema_list = [
+                (
+                    "unit_id",
+                    _microdata_data_type_to_pyarrow(identifier_data_type),
+                ),
+                (
+                    "value",
+                    _microdata_data_type_to_disk_pyarrow(measure_data_type),
+                ),
+                ("start_epoch_days", pyarrow.int16()),
+                ("stop_epoch_days", pyarrow.int16()),
+            ]
+            if temporality_type in ["STATUS", "ACCUMULATED"]:
+                schema_list.append(("start_year", pyarrow.string()))
+            schema = pyarrow.schema(schema_list)
+            with parquet.ParquetWriter(output_parquet_path, schema) as writer:
+                _csv_stream_to_parquet(
+                    identifier_data_type,
+                    measure_data_type,
+                    temporality_type,
+                    reader,
+                    writer,
+                )
+        return pyarrow.dataset.dataset(output_parquet_path)
     except ArrowInvalid as e:
         raise ValidationError(
             "Error when reading dataset", errors=[str(e)]
@@ -121,34 +200,55 @@ def _generate_start_year(table: pyarrow.Table) -> pyarrow.Array:
     )
 
 
-def read_and_sanitize_csv(
+def read_and_sanitize_csv_write_parquet(
     input_data_path: Path,
+    output_parquet_path: Path,
     identifier_data_type: str,
     measure_data_type: str,
     temporality_type: str,
-) -> pyarrow.Table:
+) -> pyarrow.dataset.FileSystemDataset:
     """
-    Reads a csv file to a pyarrow table. Sanitizes values and
+    Streams a csv file to a parquet file. Sanitizes values and
     ensures the input csv data follows the requirements for the
     microdata data model.
     """
-    table = _csv_to_table(
-        input_data_path, identifier_data_type, measure_data_type
+    return _csv_to_parquet(
+        input_data_path,
+        output_parquet_path,
+        identifier_data_type,
+        measure_data_type,
+        temporality_type,
     )
-    unit_id = _sanitize_unit_id(table, identifier_data_type)
-    value = _sanitize_value(table, measure_data_type)
-    epoch_start = _cast_to_epoch_date(table, "start")
-    epoch_stop = _cast_to_epoch_date(table, "stop")
-    columns = [unit_id, value, epoch_start, epoch_stop]
-    column_names = ["unit_id", "value", "start_epoch_days", "stop_epoch_days"]
-    if temporality_type in ["STATUS", "ACCUMULATED"]:
-        columns.append(_generate_start_year(table))
-        column_names.append("start_year")
-    return pyarrow.Table.from_arrays(columns, column_names)
+
+
+def _min_max(
+    filesystem_dataset: ds.FileSystemDataset, column: str
+) -> tuple[int | None, int | None]:
+    min_v: int | None = None
+    max_v: int | None = None
+    for batch in filesystem_dataset.to_batches(columns=[column]):
+        maybe_min, maybe_max = compute.min_max(batch[column]).as_py().values()
+        if maybe_min is not None:
+            min_v = maybe_min if min_v is None else min(min_v, maybe_min)
+        if maybe_max is not None:
+            max_v = maybe_max if max_v is None else max(max_v, maybe_max)
+    return min_v, max_v
+
+
+def _max(
+    filesystem_dataset: pyarrow.dataset.FileSystemDataset, column: str
+) -> Tuple[int | None, int | None]:
+    return _min_max(filesystem_dataset, column)[1]
+
+
+def _min(
+    filesystem_dataset: pyarrow.dataset.FileSystemDataset, column: str
+) -> Tuple[int | None, int | None]:
+    return _min_max(filesystem_dataset, column)[0]
 
 
 def get_temporal_data(
-    table: pyarrow.Table, temporality_type: str
+    dataset: pyarrow.dataset.FileSystemDataset, temporality_type: str
 ) -> Dict[str, int]:
     """
     Reads the temporal columns of the pyarrow.Table and
@@ -157,7 +257,7 @@ def get_temporal_data(
     """
     temporal_data = {}
     if temporality_type == "FIXED":
-        stop_max = compute.max(table["stop_epoch_days"]).as_py()
+        stop_max = _max(dataset, "stop_epoch_days")
         if stop_max is None:
             error_string = (
                 "Could not read data in fourth column (Stop date)."
@@ -169,12 +269,8 @@ def get_temporal_data(
             datetime(1970, 1, 1) + timedelta(days=stop_max)
         ).strftime("%Y-%m-%d")
     else:
-        start_min, start_max = (
-            compute.min_max(table["start_epoch_days"]).as_py().values()
-        )
-        stop_min, stop_max = (
-            compute.min_max(table["stop_epoch_days"]).as_py().values()
-        )
+        start_min, start_max = _min_max(dataset, "start_epoch_days")
+        stop_min, stop_max = _min_max(dataset, "stop_epoch_days")
         if start_min is None or start_max is None:
             error_string = (
                 "Could not read data in third column (Start date)."
@@ -206,7 +302,9 @@ def get_temporal_data(
                 "%Y-%m-%d"
             )
             for status_days in compute.unique(
-                table["start_epoch_days"]
+                dataset.to_table(columns=["start_epoch_days"])[
+                    "start_epoch_days"
+                ]
             ).to_pylist()
         ]
     return temporal_data

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,6 @@
+import os
+
+
 def pytest_addoption(parser):
     parser.addoption(
         "--include-big-data",
@@ -6,3 +9,42 @@ def pytest_addoption(parser):
         default=False,
         help="enable big data testing",
     )
+    parser.addoption(
+        "--keep-big-data-csv-files",
+        action="store_true",
+        dest="keep-big-data-csv-files",
+        default=False,
+        help="Don't delete big data CSV files",
+    )
+    parser.addoption(
+        "--big-data-row-count",
+        action="store",
+        dest="big-data-row-count",
+        default="10_000_000",
+        help="Number of rows to use for big datasets test",
+    )
+
+
+if "quiet" == os.environ.get("MICRODATA_TOOLS_TEST_PROGRESS"):
+
+    def pytest_report_teststatus(report):
+        category, short, verbose = "", "", ""
+        if hasattr(report, "wasxfail"):
+            if report.skipped:
+                category = "xfailed"
+                verbose = "xfail"
+            elif report.passed:
+                category = "xpassed"
+                verbose = ("XPASS", {"yellow": True})
+            return (category, short, verbose)
+        elif report.when in ("setup", "teardown"):
+            if report.failed:
+                category = "error"
+                verbose = "ERROR"
+            elif report.skipped:
+                category = "skipped"
+                verbose = "SKIPPED"
+            return (category, short, verbose)
+        category = report.outcome
+        verbose = category.upper()
+        return (category, short, verbose)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,343 @@
+import os
+from itertools import chain
+from pathlib import Path
+from typing import Dict
+
+from pyarrow import Table, dataset, parquet
+
+PARQUET_DIR = Path(
+    "tmp/tests/resources/validation/steps/dataset_validator/parquet"
+)
+
+
+def _dataset_from_dict(name: str, table_dict: Dict):
+    os.makedirs(PARQUET_DIR, exist_ok=True)
+    parquet_path = PARQUET_DIR / f"{name}.parquet"
+    parquet.write_table(Table.from_pydict(table_dict), parquet_path)
+    return dataset.dataset(parquet_path)
+
+
+def _delete_parquet_files():
+    parquet_files = [f for f in os.listdir(PARQUET_DIR) if "parquet" in f]
+    for f in parquet_files:
+        try:
+            os.remove(PARQUET_DIR / f)
+        except Exception:
+            ...
+
+
+# ------------------
+# MEASURE: CODE LIST
+# ------------------
+FIXED_STRING_CODELIST = [
+    {
+        "code": "1",
+        "categoryTitle": [{"languageCode": "no", "value": "Ugift"}],
+        "validFrom": "1926-01-01",
+    },
+    {
+        "code": "2",
+        "categoryTitle": [{"languageCode": "no", "value": "Gift"}],
+        "validFrom": "1926-01-01",
+    },
+]
+FIXED_STRING_CODELIST_SENTINEL = [
+    {
+        "code": "0",
+        "categoryTitle": [{"languageCode": "no", "value": "Sivilstand ukjent"}],
+    }
+]
+
+
+def FIXED_STRING_CODELIST_DS():
+    return _dataset_from_dict(
+        "FIXED_STRING_CODELIST_DS",
+        {
+            "unit_id": ["1", "2", "3", "4"],
+            "value": ["0", "1", "2", "1"],
+            "start_year": [None] * 4,
+            "start_epoch_days": [None] * 4,
+            "stop_epoch_days": [18262] * 4,
+        },
+    )
+
+
+def FIXED_STRING_CODELIST_INVALID_DS():
+    return _dataset_from_dict(
+        "FIXED_STRING_CODELIST_INVALID_DS",
+        {
+            "unit_id": ["1", "2", "3", "4"],
+            "value": ["0", "1", "2", "3"],
+            "start_year": [None] * 4,
+            "start_epoch_days": [None] * 4,
+            "stop_epoch_days": [18262] * 4,
+        },
+    )
+
+
+# -------------------
+# MEASURE: DATA TYPE
+# -------------------
+_FIXED_DS_TEMPLATE = {
+    "unit_id": ["1", "2", "3", "4"],
+    "start_year": [None] * 4,
+    "start_epoch_days": [None] * 4,
+    "stop_epoch_days": [18262] * 4,
+}
+
+
+def FIXED_STRING_DS():
+    return _dataset_from_dict(
+        "FIXED_STRING_DS",
+        {
+            **_FIXED_DS_TEMPLATE,
+            "value": ["0", "b", "2c", "3"],
+        },
+    )
+
+
+def FIXED_STRING_INVALID_DS():
+    return _dataset_from_dict(
+        "FIXED_STRING_INVALID_DS",
+        {
+            **_FIXED_DS_TEMPLATE,
+            "value": ["ab", "", None, "3"],
+        },
+    )
+
+
+def FIXED_LONG_DS():
+    return _dataset_from_dict(
+        "FIXED_LONG_DS",
+        {
+            **_FIXED_DS_TEMPLATE,
+            "value": [0, -1, 1, 2],
+        },
+    )
+
+
+def FIXED_LONG_INVALID_DS():
+    return _dataset_from_dict(
+        "FIXED_LONG_INVALID_DS",
+        {
+            **_FIXED_DS_TEMPLATE,
+            "value": [0, -1, 1, None],
+        },
+    )
+
+
+def FIXED_DOUBLE_DS():
+    return _dataset_from_dict(
+        "FIXED_DOUBLE_DS",
+        {
+            **_FIXED_DS_TEMPLATE,
+            "value": [0.1, -0.32, 0.003, -0.1],
+        },
+    )
+
+
+def FIXED_DOUBLE_INVALID_DS():
+    return _dataset_from_dict(
+        "FIXED_DOUBLE_INVALID_DS",
+        {
+            **_FIXED_DS_TEMPLATE,
+            "value": [0.1, -0.32, 0.003, None],
+        },
+    )
+
+
+def FIXED_DATE_DS():
+    return _dataset_from_dict(
+        "FIXED_DATE_DS",
+        {
+            **_FIXED_DS_TEMPLATE,
+            "value": [18626, 18626, 18626, 18626],
+        },
+    )
+
+
+def FIXED_DATE_INVALID_DS():
+    return _dataset_from_dict(
+        "FIXED_DATE_INVALID_DS",
+        {
+            **_FIXED_DS_TEMPLATE,
+            "value": [18626, 18626, 18626, None],
+        },
+    )
+
+
+# -------------------------
+# TEMPORALITY: FIXED
+# -------------------------
+_FIXED_VALID_DICT = {
+    "unit_id": ["1", "2", "3", "4"],
+    "value": ["1", "2", "3", "4"],
+    "start_year": [None] * 4,
+    "start_epoch_days": [None] * 4,
+    "stop_epoch_days": [18262] * 4,
+}
+
+
+def FIXED_VALID_DS():
+    return _dataset_from_dict("FIXED_VALID_DS", _FIXED_VALID_DICT)
+
+
+def FIXED_INVALID_START_DS():
+    return _dataset_from_dict(
+        "FIXED_INVALID_START_DS",
+        {
+            **_FIXED_VALID_DICT,
+            "start_year": ["2020"] * 4,
+            "start_epoch_days": [18626] * 4,
+        },
+    )
+
+
+def FIXED_INVALID_DUPLICATES_DS():
+    return _dataset_from_dict(
+        "FIXED_INVALID_DUPLICATES_DS",
+        {**_FIXED_VALID_DICT, "unit_id": ["1", "2", "3", "3"]},
+    )
+
+
+# -------------------------
+# TEMPORALITY: STATUS
+# -------------------------
+_STATUS_VALID_DICT = {
+    "unit_id": ["1", "2", "3", "4"],
+    "value": ["1", "2", "3", "4"],
+    "start_year": ["2020"] * 4,
+    "start_epoch_days": [18626] * 4,
+    "stop_epoch_days": [18626] * 4,
+}
+
+
+def STATUS_VALID_DS():
+    return _dataset_from_dict("STATUS_VALID_DS", _STATUS_VALID_DICT)
+
+
+def STATUS_INVALID_START_STOP_DS():
+    return _dataset_from_dict(
+        "STATUS_INVALID_START_STOP_DS",
+        {**_STATUS_VALID_DICT, "start_epoch_days": [18727] * 4},
+    )
+
+
+def STATUS_INVALID_DUPLICATES_DS():
+    return _dataset_from_dict(
+        "STATUS_INVALID_DUPLICATES_DS",
+        {**_STATUS_VALID_DICT, "unit_id": ["1", "2", "3", "3"]},
+    )
+
+
+# -------------------------
+# TEMPORALITY: EVENT
+# -------------------------
+_EVENT_VALID_DICT = {
+    "unit_id": ["1", "1", "2", "3"],
+    "value": ["1", "2", "3", "4"],
+    "start_year": ["2020"] * 4,
+    "start_epoch_days": [18626, 18671, 18626, 18626],
+    "stop_epoch_days": [18670, 18680, 18627, None],
+}
+
+
+def EVENT_VALID_DS():
+    return _dataset_from_dict("EVENT_VALID_DS", _EVENT_VALID_DICT)
+
+
+def EVENT_INVALID_OVERLAP_DS():
+    return _dataset_from_dict(
+        "EVENT_INVALID_OVERLAP_DS",
+        {**_EVENT_VALID_DICT, "start_epoch_days": [18626, 18670, 18626, 18626]},
+    )
+
+
+def EVENT_INVALID_START_DS():
+    return _dataset_from_dict(
+        "EVENT_INVALID_START_DS",
+        {**_EVENT_VALID_DICT, "start_epoch_days": [None, 18271, 18626, 18626]},
+    )
+
+
+def EVENT_INVALID_TIMESPANS_DS():
+    return _dataset_from_dict(
+        "EVENT_INVALID_TIMESPANS_DS",
+        {**_EVENT_VALID_DICT, "start_epoch_days": [18626, 18627, 18626, 18626]},
+    )
+
+
+def EVENT_TOO_MANY_ERRORS_DS():
+    return _dataset_from_dict(
+        "EVENT_TOO_MANY_ERRORS_DS",
+        {
+            "unit_id": list(
+                chain.from_iterable([str(i), str(i)] for i in range(100))
+            ),
+            "value": [str(i) for i in range(200)],
+            "start_year": ["2020"] * 200,
+            "start_epoch_days": [18626] * 200,
+            "stop_epoch_days": [None] * 200,
+        },
+    )
+
+
+# -------------------------
+# TEMPORALITY: ACCUMULATED
+# -------------------------
+_ACCUMULATED_VALID_DICT = {
+    "unit_id": ["1", "1", "2", "3"],
+    "value": ["1", "2", "3", "4"],
+    "start_year": ["2020"] * 4,
+    "start_epoch_days": [18626, 18671, 18626, 18626],
+    "stop_epoch_days": [18670, 18672, 18627, 18627],
+}
+
+
+def ACCUMULATED_VALID_DS():
+    return _dataset_from_dict("ACCUMULATED_VALID_DS", _ACCUMULATED_VALID_DICT)
+
+
+def ACCUMULATED_INVALID_START_STOP_DS():
+    return _dataset_from_dict(
+        "ACCUMULATED_INVALID_START_STOP_DS",
+        {
+            **_ACCUMULATED_VALID_DICT,
+            "start_epoch_days": [18626, None, 18264, 18262],
+            "stop_epoch_days": [None, 18280, 18263, 18263],
+        },
+    )
+
+
+def ACCUMULATED_INVALID_TIMESPANS_DS():
+    return _dataset_from_dict(
+        "ACCUMULATED_INVALID_TIMESPANS_DS",
+        {
+            **_ACCUMULATED_VALID_DICT,
+            "start_epoch_days": [18626, 18627, 18626, 18626],
+        },
+    )
+
+
+# ----------------------
+# TOO MANY ERRORS
+# ----------------------
+TOO_MANY_ERRORS_CODELIST = [
+    {
+        "code": "1",
+        "categoryTitle": [{"languageCode": "no", "value": "Valid"}],
+        "validFrom": "1926-01-01",
+    },
+]
+
+_TOO_MANY_ERRORS_DICT = {
+    "unit_id": [str(i) for i in range(60)],
+    "value": [str(i) for i in range(60)],
+    "start_year": ["2020"] * 60,
+    "start_epoch_days": [18626] * 60,
+    "stop_epoch_days": [18670] * 60,
+}
+
+
+def TOO_MANY_ERRORS_DS():
+    return _dataset_from_dict("TOO_MANY_ERRORS_DS", _TOO_MANY_ERRORS_DICT)

--- a/tests/test_packaging/test_package_dataset.py
+++ b/tests/test_packaging/test_package_dataset.py
@@ -10,18 +10,24 @@ from pytest import MonkeyPatch
 
 from microdata_tools import package_dataset
 
-RSA_KEYS_DIRECTORY = Path("tests/resources/packaging/rsa_keys")
-INPUT_DIRECTORY = Path("tests/resources/packaging/input_package")
-OUTPUT_DIRECTORY = Path("tests/resources/packaging/output")
+RSA_KEYS_DIRECTORY = Path("tmp/tests/resources/packaging/rsa_keys")
+INPUT_DIRECTORY = Path("tmp/tests/resources/packaging/input_package")
+OUTPUT_DIRECTORY = Path("tmp/tests/resources/packaging/output")
 
 
 def setup_function():
-    shutil.copytree("tests/resources", "tests/resources_backup")
+    if os.path.exists("tmp/tests/resources"):
+        shutil.rmtree("tmp/tests/resources")
+    shutil.copytree(
+        "tests/resources",
+        "tmp/tests/resources",
+        ignore=shutil.ignore_patterns("*big_datasets*"),
+    )
 
 
 def teardown_function():
-    shutil.rmtree("tests/resources")
-    shutil.move("tests/resources_backup", "tests/resources")
+    if os.path.exists("tmp/tests/resources"):
+        shutil.rmtree("tmp/tests/resources")
 
 
 def test_package_dataset():

--- a/tests/test_packaging/test_unpackage_dataset.py
+++ b/tests/test_packaging/test_unpackage_dataset.py
@@ -15,18 +15,24 @@ from microdata_tools.packaging.exceptions import (
 )
 from tests.test_packaging.test_package_dataset import _create_rsa_public_key
 
-RSA_KEYS_DIRECTORY = Path("tests/resources/packaging/rsa_test_key")
-INPUT_DIRECTORY = Path("tests/resources/packaging/input_unpackage")
-OUTPUT_DIRECTORY = Path("tests/resources/packaging/output")
+RSA_KEYS_DIRECTORY = Path("tmp/tests/resources/packaging/rsa_test_key")
+INPUT_DIRECTORY = Path("tmp/tests/resources/packaging/input_unpackage")
+OUTPUT_DIRECTORY = Path("tmp/tests/resources/packaging/output")
 
 
 def setup_function():
-    shutil.copytree("tests/resources", "tests/resources_backup")
+    if os.path.exists("tmp/tests/resources"):
+        shutil.rmtree("tmp/tests/resources")
+    shutil.copytree(
+        "tests/resources",
+        "tmp/tests/resources",
+        ignore=shutil.ignore_patterns("*big_datasets*"),
+    )
 
 
 def teardown_function():
-    shutil.rmtree("tests/resources")
-    shutil.move("tests/resources_backup", "tests/resources")
+    if os.path.exists("tmp/tests/resources"):
+        shutil.rmtree("tmp/tests/resources")
 
 
 def test_validate_tar_contents():
@@ -106,7 +112,7 @@ def test_unpackage_dataset():
 
 def test_unpackage_dataset_multiple_chunks(monkeypatch: MonkeyPatch):
     dataset_name = "VALID"
-    rsa_key = Path("tests/resources/rsa_keys")
+    rsa_key = Path("tmp/tests/resources/rsa_keys")
 
     _create_rsa_public_key(target_dir=rsa_key)
     assert Path(rsa_key / "microdata_public_key.pem").exists()
@@ -116,11 +122,13 @@ def test_unpackage_dataset_multiple_chunks(monkeypatch: MonkeyPatch):
         "microdata_tools.packaging._encrypt.CHUNK_SIZE_BYTES", 1
     )
 
+    if os.path.exists("tmp/tests/resources/packaging/input_unpackage"):
+        shutil.rmtree("tmp/tests/resources/packaging/input_unpackage")
+    dataset_dir = f"tmp/tests/resources/packaging/input_package/{dataset_name}"
+
     package_dataset(
         rsa_keys_dir=rsa_key,
-        dataset_dir=Path(
-            f"tests/resources/packaging/input_package/{dataset_name}"
-        ),
+        dataset_dir=Path(dataset_dir),
         output_dir=INPUT_DIRECTORY,
     )
 
@@ -141,7 +149,7 @@ def test_unpackage_dataset_multiple_chunks(monkeypatch: MonkeyPatch):
 
     actual = Path(output_dataset_dir / f"{dataset_name}.csv")
     expected = Path(
-        f"tests/resources/packaging/expected_unpackage/{dataset_name}_expected.csv"
+        f"tmp/tests/resources/packaging/expected_unpackage/{dataset_name}_expected.csv"
     )
     assert filecmp.cmp(actual, expected)
 

--- a/tests/test_validation/steps/test_data_reader.py
+++ b/tests/test_validation/steps/test_data_reader.py
@@ -1,3 +1,5 @@
+import os
+import shutil
 from pathlib import Path
 
 import pyarrow
@@ -13,6 +15,34 @@ EXPECTED_COLUMNS = {
     "start_epoch_days": [None, 18262, 18262],
     "stop_epoch_days": [18262, 18262, 18262],
 }
+
+
+def _csv_to_table(
+    csv_data_path, identifier_data_type, measure_data_type, temporality_type
+):
+    os.makedirs("tmp", exist_ok=True)
+    output_parquet_path = "tmp/tmp.parquet"
+    return data_reader.read_and_sanitize_csv_write_parquet(
+        csv_data_path,
+        Path(output_parquet_path),
+        identifier_data_type,
+        measure_data_type,
+        temporality_type,
+    ).to_table()
+
+
+def _get_temporal_data(table: pyarrow.Table, temporality_type: str):
+    os.makedirs("tmp", exist_ok=True)
+    pyarrow.parquet.write_table(table, "tmp/tmp.parquet")
+    ds = pyarrow.dataset.dataset("tmp/tmp.parquet")
+    return data_reader.get_temporal_data(ds, temporality_type)
+
+
+def teardown_function():
+    try:
+        shutil.rmtree("tmp")
+    except Exception:
+        pass
 
 
 def test_get_temporal_data():
@@ -44,24 +74,24 @@ def test_get_temporal_data():
     }
 
     fixed_table = pyarrow.Table.from_pydict(fixed_dict, schema=table_schema)
-    assert data_reader.get_temporal_data(fixed_table, "FIXED") == {
+    assert _get_temporal_data(fixed_table, "FIXED") == {
         "start": "1900-01-01",
         "latest": "1970-01-06",
     }
     event_table = pyarrow.Table.from_pydict(event_dict, schema=table_schema)
-    assert data_reader.get_temporal_data(event_table, "EVENT") == {
+    assert _get_temporal_data(event_table, "EVENT") == {
         "start": "1970-01-02",
         "latest": "1970-01-06",
     }
     accumulated_table = pyarrow.Table.from_pydict(
         accumulated_dict, schema=table_schema
     )
-    assert data_reader.get_temporal_data(accumulated_table, "ACCUMULATED") == {
+    assert _get_temporal_data(accumulated_table, "ACCUMULATED") == {
         "start": "1970-01-02",
         "latest": "1970-01-06",
     }
     status_table = pyarrow.Table.from_pydict(status_dict, schema=table_schema)
-    assert data_reader.get_temporal_data(status_table, "STATUS") == {
+    assert _get_temporal_data(status_table, "STATUS") == {
         "start": "1970-01-02",
         "latest": "1970-01-06",
         "statusDates": [
@@ -73,7 +103,10 @@ def test_get_temporal_data():
         ],
     }
     with pytest.raises(ValidationError) as e:
-        data_reader.get_temporal_data(empty_table, "EVENT")
+        empty_table = pyarrow.Table.from_pydict(
+            empty_table, schema=table_schema
+        )
+        _get_temporal_data(empty_table, "EVENT")
     assert e.value.errors == [
         "Could not read data in third column (Start date). Is this column empty"
         "?"
@@ -82,7 +115,7 @@ def test_get_temporal_data():
 
 def test_sanitize_long():
     long_data_path = INPUT_DIR / "LONG.csv"
-    assert data_reader.read_and_sanitize_csv(
+    assert _csv_to_table(
         long_data_path, "STRING", "LONG", "FIXED"
     ).to_pydict() == {
         **EXPECTED_COLUMNS,
@@ -90,9 +123,7 @@ def test_sanitize_long():
     }
     with pytest.raises(ValidationError) as e:
         invalid_data_path = INPUT_DIR / "LONG_INVALID_VALUE.csv"
-        assert data_reader.read_and_sanitize_csv(
-            invalid_data_path, "STRING", "LONG", "FIXED"
-        )
+        _csv_to_table(invalid_data_path, "STRING", "LONG", "FIXED")
     assert e.value.errors == [
         "In CSV column #1: CSV conversion error to int64: invalid value "
         "'abc123'"
@@ -101,7 +132,7 @@ def test_sanitize_long():
 
 def test_sanitize_double():
     double_data_path = INPUT_DIR / "DOUBLE.csv"
-    assert data_reader.read_and_sanitize_csv(
+    assert _csv_to_table(
         double_data_path, "STRING", "DOUBLE", "FIXED"
     ).to_pydict() == {
         **EXPECTED_COLUMNS,
@@ -109,9 +140,7 @@ def test_sanitize_double():
     }
     with pytest.raises(ValidationError) as e:
         invalid_data_path = INPUT_DIR / "DOUBLE_INVALID_FORMAT.csv"
-        assert data_reader.read_and_sanitize_csv(
-            invalid_data_path, "STRING", "DOUBLE", "FIXED"
-        )
+        _csv_to_table(invalid_data_path, "STRING", "DOUBLE", "FIXED")
     assert e.value.errors == [
         "In CSV column #1: CSV conversion error to double: invalid value "
         "'12345,12345'"
@@ -120,7 +149,7 @@ def test_sanitize_double():
 
 def test_sanitize_date():
     date_data_path = INPUT_DIR / "DATE.csv"
-    assert data_reader.read_and_sanitize_csv(
+    assert _csv_to_table(
         date_data_path, "STRING", "DATE", "FIXED"
     ).to_pydict() == {
         **EXPECTED_COLUMNS,
@@ -128,9 +157,7 @@ def test_sanitize_date():
     }
     with pytest.raises(ValidationError) as e:
         invalid_data_path = INPUT_DIR / "DATE_INVALID_VALUE.csv"
-        assert data_reader.read_and_sanitize_csv(
-            invalid_data_path, "STRING", "DATE", "FIXED"
-        )
+        _csv_to_table(invalid_data_path, "STRING", "DATE", "FIXED")
     assert e.value.errors == [
         "In CSV column #1: CSV conversion error to date32[day]: invalid value "
         "'2020-13-01'"
@@ -139,7 +166,7 @@ def test_sanitize_date():
 
 def test_sanitize_string():
     string_data_path = INPUT_DIR / "STRING.csv"
-    assert data_reader.read_and_sanitize_csv(
+    assert _csv_to_table(
         string_data_path, "STRING", "STRING", "FIXED"
     ).to_pydict() == {
         **EXPECTED_COLUMNS,
@@ -150,9 +177,7 @@ def test_sanitize_string():
 def test_sanitize_data_invalid_start_stop():
     with pytest.raises(ValidationError) as e:
         invalid_data_path = INPUT_DIR / "STRING_INVALID_START_STOP.csv"
-        assert data_reader.read_and_sanitize_csv(
-            invalid_data_path, "STRING", "STRING", "FIXED"
-        )
+        _csv_to_table(invalid_data_path, "STRING", "STRING", "FIXED")
     assert e.value.errors == [
         "In CSV column #3: CSV conversion error to date32[day]: invalid value "
         "'2020-13-01'"
@@ -162,9 +187,7 @@ def test_sanitize_data_invalid_start_stop():
 def test_sanitize_data_wrong_delimiter():
     with pytest.raises(ValidationError) as e:
         invalid_data_path = INPUT_DIR / "STRING_INVALID_DELIMITER.csv"
-        assert data_reader.read_and_sanitize_csv(
-            invalid_data_path, "STRING", "STRING", "FIXED"
-        )
+        _csv_to_table(invalid_data_path, "STRING", "STRING", "FIXED")
     assert e.value.errors == [
         "CSV parse error: Expected 5 columns, got 1: 000001,abc123,2020-01-01,"
     ]
@@ -173,9 +196,7 @@ def test_sanitize_data_wrong_delimiter():
 def test_sanitize_data_empty_file():
     with pytest.raises(ValidationError) as e:
         invalid_data_path = INPUT_DIR / "STRING_EMPTY_FILE.csv"
-        assert data_reader.read_and_sanitize_csv(
-            invalid_data_path, "STRING", "STRING", "FIXED"
-        )
+        _csv_to_table(invalid_data_path, "STRING", "STRING", "FIXED")
     assert e.value.errors == ["Empty CSV file"]
 
 
@@ -186,7 +207,7 @@ def test_sanitize_data_start_year():
         "start_year": ["2019", "2020", "2020"],
     }
     status_data_path = INPUT_DIR / "STRING_STATUS.csv"
-    assert data_reader.read_and_sanitize_csv(
+    assert _csv_to_table(
         status_data_path, "STRING", "STRING", "STATUS"
     ).to_pydict() == {
         **expected_columns,
@@ -194,7 +215,7 @@ def test_sanitize_data_start_year():
         "stop_epoch_days": [17897, 18262, 18262],
     }
     accumulated_data_path = INPUT_DIR / "STRING_ACCUMULATED.csv"
-    assert data_reader.read_and_sanitize_csv(
+    assert _csv_to_table(
         accumulated_data_path, "STRING", "STRING", "ACCUMULATED"
     ).to_pydict() == {
         **expected_columns,

--- a/tests/test_validation/steps/test_dataset_validator.py
+++ b/tests/test_validation/steps/test_dataset_validator.py
@@ -2,7 +2,7 @@ import pytest
 
 from microdata_tools.validation.exceptions import ValidationError
 from microdata_tools.validation.steps import dataset_validator
-from tests.resources.validation.steps.dataset_validator import test_data
+from tests import test_data
 
 
 def teardown_module():
@@ -13,7 +13,7 @@ def test_measure_code_list_validation():
     code_list = test_data.FIXED_STRING_CODELIST
     sentinel_list = test_data.FIXED_STRING_CODELIST_SENTINEL
     dataset_validator.validate_dataset(
-        test_data.FIXED_STRING_CODELIST_DS,
+        test_data.FIXED_STRING_CODELIST_DS(),
         "STRING",
         code_list,
         sentinel_list,
@@ -21,7 +21,7 @@ def test_measure_code_list_validation():
     )
     with pytest.raises(ValidationError) as e:
         dataset_validator.validate_dataset(
-            test_data.FIXED_STRING_CODELIST_INVALID_DS,
+            test_data.FIXED_STRING_CODELIST_INVALID_DS(),
             "STRING",
             code_list,
             sentinel_list,
@@ -32,7 +32,7 @@ def test_measure_code_list_validation():
 
 def test_measure_data_type_string_validation():
     dataset_validator.validate_dataset(
-        test_data.FIXED_STRING_DS,
+        test_data.FIXED_STRING_DS(),
         "STRING",
         None,
         None,
@@ -40,7 +40,7 @@ def test_measure_data_type_string_validation():
     )
     with pytest.raises(ValidationError) as e:
         dataset_validator.validate_dataset(
-            test_data.FIXED_STRING_INVALID_DS,
+            test_data.FIXED_STRING_INVALID_DS(),
             "STRING",
             None,
             None,
@@ -54,7 +54,7 @@ def test_measure_data_type_string_validation():
 
 def test_measure_data_type_long_validation():
     dataset_validator.validate_dataset(
-        test_data.FIXED_LONG_DS,
+        test_data.FIXED_LONG_DS(),
         "LONG",
         None,
         None,
@@ -62,7 +62,7 @@ def test_measure_data_type_long_validation():
     )
     with pytest.raises(ValidationError) as e:
         dataset_validator.validate_dataset(
-            test_data.FIXED_LONG_INVALID_DS,
+            test_data.FIXED_LONG_INVALID_DS(),
             "LONG",
             None,
             None,
@@ -75,7 +75,7 @@ def test_measure_data_type_long_validation():
 
 def test_measure_data_type_double_validation():
     dataset_validator.validate_dataset(
-        test_data.FIXED_DOUBLE_DS,
+        test_data.FIXED_DOUBLE_DS(),
         "DOUBLE",
         None,
         None,
@@ -83,7 +83,7 @@ def test_measure_data_type_double_validation():
     )
     with pytest.raises(ValidationError) as e:
         dataset_validator.validate_dataset(
-            test_data.FIXED_DOUBLE_INVALID_DS,
+            test_data.FIXED_DOUBLE_INVALID_DS(),
             "DOUBLE",
             None,
             None,
@@ -96,7 +96,7 @@ def test_measure_data_type_double_validation():
 
 def test_measure_data_type_date_validation():
     dataset_validator.validate_dataset(
-        test_data.FIXED_DATE_DS,
+        test_data.FIXED_DATE_DS(),
         "DATE",
         None,
         None,
@@ -104,7 +104,7 @@ def test_measure_data_type_date_validation():
     )
     with pytest.raises(ValidationError) as e:
         dataset_validator.validate_dataset(
-            test_data.FIXED_DATE_INVALID_DS,
+            test_data.FIXED_DATE_INVALID_DS(),
             "DATE",
             None,
             None,
@@ -117,7 +117,7 @@ def test_measure_data_type_date_validation():
 
 def test_temporality_fixed():
     dataset_validator.validate_dataset(
-        test_data.FIXED_VALID_DS,
+        test_data.FIXED_VALID_DS(),
         "STRING",
         None,
         None,
@@ -125,7 +125,7 @@ def test_temporality_fixed():
     )
     with pytest.raises(ValidationError) as e:
         dataset_validator.validate_dataset(
-            test_data.FIXED_INVALID_START_DS,
+            test_data.FIXED_INVALID_START_DS(),
             "STRING",
             None,
             None,
@@ -137,7 +137,7 @@ def test_temporality_fixed():
     ]
     with pytest.raises(ValidationError) as e:
         dataset_validator.validate_dataset(
-            test_data.FIXED_INVALID_DUPLICATES_DS,
+            test_data.FIXED_INVALID_DUPLICATES_DS(),
             "STRING",
             None,
             None,
@@ -148,7 +148,7 @@ def test_temporality_fixed():
 
 def test_temporality_status():
     dataset_validator.validate_dataset(
-        test_data.STATUS_VALID_DS,
+        test_data.STATUS_VALID_DS(),
         "STRING",
         None,
         None,
@@ -156,7 +156,7 @@ def test_temporality_status():
     )
     with pytest.raises(ValidationError) as e:
         dataset_validator.validate_dataset(
-            test_data.STATUS_INVALID_START_STOP_DS,
+            test_data.STATUS_INVALID_START_STOP_DS(),
             "STRING",
             None,
             None,
@@ -168,7 +168,7 @@ def test_temporality_status():
     ]
     with pytest.raises(ValidationError) as e:
         dataset_validator.validate_dataset(
-            test_data.STATUS_INVALID_DUPLICATES_DS,
+            test_data.STATUS_INVALID_DUPLICATES_DS(),
             "STRING",
             None,
             None,
@@ -181,7 +181,7 @@ def test_temporality_status():
 
 def test_temporality_event():
     dataset_validator.validate_dataset(
-        test_data.EVENT_VALID_DS,
+        test_data.EVENT_VALID_DS(),
         "STRING",
         None,
         None,
@@ -189,7 +189,7 @@ def test_temporality_event():
     )
     with pytest.raises(ValidationError) as e:
         dataset_validator.validate_dataset(
-            test_data.EVENT_INVALID_START_DS,
+            test_data.EVENT_INVALID_START_DS(),
             "STRING",
             None,
             None,
@@ -200,7 +200,7 @@ def test_temporality_event():
     ]
     with pytest.raises(ValidationError) as e:
         dataset_validator.validate_dataset(
-            test_data.EVENT_INVALID_OVERLAP_DS,
+            test_data.EVENT_INVALID_OVERLAP_DS(),
             "STRING",
             None,
             None,
@@ -216,7 +216,7 @@ def test_temporality_event():
 
     with pytest.raises(ValidationError) as e:
         dataset_validator.validate_dataset(
-            test_data.EVENT_INVALID_TIMESPANS_DS,
+            test_data.EVENT_INVALID_TIMESPANS_DS(),
             "STRING",
             None,
             None,
@@ -231,7 +231,7 @@ def test_temporality_event():
     ]
     with pytest.raises(ValidationError) as e:
         dataset_validator.validate_dataset(
-            test_data.EVENT_TOO_MANY_ERRORS_DS,
+            test_data.EVENT_TOO_MANY_ERRORS_DS(),
             "STRING",
             None,
             None,
@@ -242,7 +242,7 @@ def test_temporality_event():
 
 def test_temporality_accumulated():
     dataset_validator.validate_dataset(
-        test_data.ACCUMULATED_VALID_DS,
+        test_data.ACCUMULATED_VALID_DS(),
         "STRING",
         None,
         None,
@@ -250,7 +250,7 @@ def test_temporality_accumulated():
     )
     with pytest.raises(ValidationError) as e:
         dataset_validator.validate_dataset(
-            test_data.ACCUMULATED_INVALID_START_STOP_DS,
+            test_data.ACCUMULATED_INVALID_START_STOP_DS(),
             "STRING",
             None,
             None,
@@ -263,13 +263,12 @@ def test_temporality_accumulated():
     ]
     with pytest.raises(ValidationError) as e:
         dataset_validator.validate_dataset(
-            test_data.ACCUMULATED_INVALID_TIMESPANS_DS,
+            test_data.ACCUMULATED_INVALID_TIMESPANS_DS(),
             "STRING",
             None,
             None,
             "ACCUMULATED",
         )
-    print(e.value.errors)
     assert e.value.errors == [
         (
             'Invalid overlapping timespans for identifier "1": '
@@ -283,7 +282,7 @@ def test_max_50_errors():
     # codelist error
     with pytest.raises(ValidationError) as e:
         dataset_validator.validate_dataset(
-            test_data.TOO_MANY_ERRORS_DS,
+            test_data.TOO_MANY_ERRORS_DS(),
             "STRING",
             test_data.TOO_MANY_ERRORS_CODELIST,
             None,
@@ -294,7 +293,7 @@ def test_max_50_errors():
     # temporal error
     with pytest.raises(ValidationError) as e:
         dataset_validator.validate_dataset(
-            test_data.TOO_MANY_ERRORS_DS,
+            test_data.TOO_MANY_ERRORS_DS(),
             "STRING",
             None,
             None,

--- a/tests/test_validation/test_validate_big_datasets.py
+++ b/tests/test_validation/test_validate_big_datasets.py
@@ -1,8 +1,14 @@
+import logging
 import os
+import shutil
+import uuid
+from pathlib import Path
 
 import pytest
 
 from microdata_tools import validate_dataset
+
+logger = logging.getLogger()
 
 RESOURCE_DIR = "tests/resources/validation/validate_dataset/big_datasets"
 
@@ -14,7 +20,20 @@ VALID_DATASET_NAMES = [
 ]
 
 
-def setup_function():
+def _get_row_count(csv_path: Path) -> int:
+    if not os.path.exists(csv_path):
+        return -1
+
+    rowcount_path = Path(str(csv_path) + ".rowcount")
+    if os.path.exists(rowcount_path) and os.path.getmtime(
+        rowcount_path
+    ) >= os.path.getmtime(csv_path):
+        with open(rowcount_path) as f:
+            return int(f.read().strip())
+    return -1
+
+
+def setup_fn(row_count):
     # The dates are intentionally shuffled to provoke errors
     identifier_dates = {
         "ACCUMULATED_DS": [
@@ -48,26 +67,60 @@ def setup_function():
     }
     for dataset_name in VALID_DATASET_NAMES:
         file_path = f"{RESOURCE_DIR}/{dataset_name}/{dataset_name}.csv"
+        if os.path.exists(file_path) and row_count == _get_row_count(
+            Path(file_path)
+        ):
+            continue
         with open(file_path, "w", encoding="utf-8") as f:
             dates = identifier_dates[dataset_name]
-            identifier_amount = 2_000_000 if len(dates) == 7 else 14_000_000
+            # len(dates) * identifier_amount = row_count
+            identifier_amount = 1 + (row_count // len(dates))
+            cnt = 0
             for date in dates:
                 for i in range(identifier_amount):
+                    cnt += 1
                     f.write(f"{i};{i};{date[0]};{date[1]};\n")
+                    if cnt == row_count:
+                        break
+                if cnt == row_count:
+                    break
+        with open(file_path + ".rowcount", "w", encoding="utf-8") as f:
+            f.write(str(row_count))
 
 
-def teardown_function():
+@pytest.fixture(autouse=True)
+def setup(pytestconfig):
+    keep_big_data_csv_files = pytestconfig.getoption(
+        "--keep-big-data-csv-files"
+    )
+    big_data_row_count = pytestconfig.getoption("--big-data-row-count")
+    row_count = int(big_data_row_count.strip().replace("_", ""))
+    assert row_count >= 1
+    try:
+        setup_fn(row_count)
+        yield
+    finally:
+        teardown(keep_big_data_csv_files)
+
+
+def teardown(keep_big_data_csv_files: bool):
     for dataset_name in VALID_DATASET_NAMES:
-        os.remove(f"{RESOURCE_DIR}/{dataset_name}/{dataset_name}.csv")
+        if not keep_big_data_csv_files:
+            os.remove(f"{RESOURCE_DIR}/{dataset_name}/{dataset_name}.csv")
+    if os.path.exists("tmp"):
+        shutil.rmtree("tmp")
 
 
 @pytest.mark.skipif("not config.getoption('include-big-data')")
-def test_validate_big_dataset():
+def test_validate_big_dataset(pytestconfig):
+    generated_working_directory = "tmp/" + str(uuid.uuid4())
+    os.makedirs(generated_working_directory, exist_ok=True)
     for dataset_name in VALID_DATASET_NAMES:
         print(f"Validating {dataset_name}")
         data_errors = validate_dataset(
             dataset_name,
             keep_temporary_files=False,
             input_directory=RESOURCE_DIR,
+            working_directory=generated_working_directory,
         )
         assert not data_errors

--- a/tests/test_validation/test_validate_dataset.py
+++ b/tests/test_validation/test_validate_dataset.py
@@ -81,7 +81,14 @@ def test_validate_valid_dataset_delete_generated_dir():
         ]
         assert not data_errors
         for file in temp_files:
-            assert file in ["tests", "docs", "microdata_tools"]
+            assert file in [
+                "tmp",
+                "mise-tasks",
+                "scripts",
+                "tests",
+                "docs",
+                "microdata_tools",
+            ]
 
 
 def test_validate_valid_dataset_delete_working_files():


### PR DESCRIPTION
The following command works on a VM with 2GB RAM:

$ uv run pytest --include-big-data --keep-big-data-csv-files --capture no --big-data-row-count 30_000_000

40M rows OOMs

This is a continuation of https://github.com/statisticsnorway/microdata-tools/pull/117